### PR TITLE
Fix some typos

### DIFF
--- a/registries/adapters/adapter.go
+++ b/registries/adapters/adapter.go
@@ -124,7 +124,7 @@ func imageToSpec(req *http.Request, image string) (*bundle.Spec, error) {
 		return nil, nil
 	}
 	if conf.Config.Label.Spec == "" {
-		log.Infof("Didn't find encoded Spec label. Assuming image is not APB and skiping")
+		log.Infof("Didn't find encoded Spec label. Assuming image is not APB and skipping")
 		return nil, nil
 	}
 

--- a/registries/adapters/mock_adapter.go
+++ b/registries/adapters/mock_adapter.go
@@ -52,7 +52,7 @@ func (r *MockAdapter) GetImageNames() ([]string, error) {
 
 	err = yaml.Unmarshal(specYaml, &parsedData)
 	if err != nil {
-		log.Error("Failed to ummarshal yaml file")
+		log.Error("Failed to unmarshal yaml file")
 		return nil, err
 	}
 

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -264,7 +264,7 @@ func (p provider) CreateSandbox(podName string,
 	log.Debugf("Successfully created network policy for pod: %v to grant network access to ns: %v", podName, targets[0])
 
 	log.Info("Successfully created apb sandbox: [ %s ], with %s permissions in namespace %s", podName, apbRole, namespace)
-	log.Info("Running post create sandbox fuctions if defined.")
+	log.Info("Running post create sandbox functions if defined.")
 	for i, f := range p.postSandboxCreate {
 		log.Debugf("Running post create sandbox function: %v", i+1)
 		err := f(podName, namespace, targets, apbRole)


### PR DESCRIPTION
While working on a bug, I noticed a typo (skiping) in the logs. Which led me to fixing other typos in the log statements.