### PR TITLE
removing the bundle execution to runtime.

### DIFF
--- a/bundle/bind.go
+++ b/bundle/bind.go
@@ -70,7 +70,7 @@ func (e *executor) Bind(
 			e.actionFinishedWithError(err)
 			return
 		}
-		ec, err = e.executeApb(ec, instance.Spec, parameters)
+		ec, err = e.executeApb(ec, instance, parameters)
 		defer runtime.Provider.DestroySandbox(
 			ec.BundleName,
 			ec.Location,
@@ -96,9 +96,9 @@ func (e *executor) Bind(
 
 		// pod execution is complete so transfer state back
 		err = e.stateManager.CopyState(
-			executionContext.PodName,
+			ec.BundleName,
 			e.stateManager.Name(instance.ID.String()),
-			executionContext.Namespace, e.stateManager.MasterNamespace())
+			ec.Location, e.stateManager.MasterNamespace())
 		if err != nil {
 			e.actionFinishedWithError(err)
 			return

--- a/bundle/bind.go
+++ b/bundle/bind.go
@@ -17,9 +17,16 @@
 package bundle
 
 import (
+	"fmt"
+
 	"github.com/automationbroker/bundle-lib/runtime"
+	"github.com/pborman/uuid"
 
 	log "github.com/sirupsen/logrus"
+)
+
+const (
+	bindAction = "bind"
 )
 
 // Bind - Will run the APB with the bind action.
@@ -37,24 +44,49 @@ func (e *executor) Bind(
 
 	go func() {
 		e.actionStarted()
-		executionContext, err := e.executeApb(
-			"bind", instance, parameters)
+		// Create namespace name that will be used to generate a name.
+		ns := fmt.Sprintf(fmt.Sprintf("%s-%.4s-", instance.Spec.FQName, bindAction))
+		// Create the podname
+		pn := fmt.Sprintf("bundle-%s", uuid.New())
+		targets := []string{instance.Context.Namespace}
+		labels := map[string]string{
+			"bundle-fqname":   instance.Spec.FQName,
+			"bundle-action":   bindAction,
+			"bundle-pod-name": pn,
+		}
+		ec := runtime.ExecutionContext{
+			BundleName: pn,
+			Targets:    targets,
+			Metadata:   labels,
+			Action:     bindAction,
+			Image:      instance.Spec.Image,
+		}
+
+		serviceAccount, namespace, err := runtime.Provider.CreateSandbox(pn, ns, targets, clusterConfig.SandboxRole, labels)
+		ec.Account = serviceAccount
+		ec.Location = namespace
+		if err != nil {
+			log.Errorf("Problem executing bundle create sandbox [%s] bind", ec.BundleName)
+			e.actionFinishedWithError(err)
+			return
+		}
+		ec, err = e.executeApb(ec, instance.Spec, parameters)
 		defer runtime.Provider.DestroySandbox(
-			executionContext.PodName,
-			executionContext.Namespace,
-			executionContext.Targets,
+			ec.BundleName,
+			ec.Location,
+			ec.Targets,
 			clusterConfig.Namespace,
 			clusterConfig.KeepNamespace,
 			clusterConfig.KeepNamespaceOnError,
 		)
 		if err != nil {
-			log.Errorf("Problem executing apb [%s] bind", executionContext.PodName)
+			log.Errorf("Problem executing apb [%s] bind", ec.BundleName)
 			e.actionFinishedWithError(err)
 			return
 		}
 
 		if instance.Spec.Runtime >= 2 {
-			err := runtime.Provider.WatchRunningBundle(executionContext.PodName, executionContext.Namespace, e.updateDescription)
+			err := runtime.Provider.WatchRunningBundle(ec.BundleName, ec.Location, e.updateDescription)
 			if err != nil {
 				log.Errorf("Bind action failed - %v", err)
 				e.actionFinishedWithError(err)
@@ -73,8 +105,8 @@ func (e *executor) Bind(
 		}
 
 		credBytes, err := runtime.Provider.ExtractCredentials(
-			executionContext.PodName,
-			executionContext.Namespace,
+			ec.BundleName,
+			ec.Location,
 			instance.Spec.Runtime,
 		)
 		if err != nil {
@@ -90,7 +122,7 @@ func (e *executor) Bind(
 			return
 		}
 
-		labels := map[string]string{"apbAction": "bind", "apbName": instance.Spec.FQName}
+		labels = map[string]string{"bundleAction": "bind", "bundleName": instance.Spec.FQName}
 		err = runtime.Provider.CreateExtractedCredential(bindingID, clusterConfig.Namespace, creds.Credentials, labels)
 		if err != nil {
 			log.Errorf("apb::%v error occurred - %v", executionMethodProvision, err)

--- a/bundle/bind.go
+++ b/bundle/bind.go
@@ -45,7 +45,7 @@ func (e *executor) Bind(
 	go func() {
 		e.actionStarted()
 		// Create namespace name that will be used to generate a name.
-		ns := fmt.Sprintf(fmt.Sprintf("%s-%.4s-", instance.Spec.FQName, bindAction))
+		ns := fmt.Sprintf("%s-%.4s-", instance.Spec.FQName, bindAction)
 		// Create the podname
 		pn := fmt.Sprintf("bundle-%s", uuid.New())
 		targets := []string{instance.Context.Namespace}
@@ -54,17 +54,17 @@ func (e *executor) Bind(
 			"bundle-action":   bindAction,
 			"bundle-pod-name": pn,
 		}
+
+		serviceAccount, namespace, err := runtime.Provider.CreateSandbox(pn, ns, targets, clusterConfig.SandboxRole, labels)
 		ec := runtime.ExecutionContext{
 			BundleName: pn,
 			Targets:    targets,
 			Metadata:   labels,
 			Action:     bindAction,
 			Image:      instance.Spec.Image,
+			Account:    serviceAccount,
+			Location:   namespace,
 		}
-
-		serviceAccount, namespace, err := runtime.Provider.CreateSandbox(pn, ns, targets, clusterConfig.SandboxRole, labels)
-		ec.Account = serviceAccount
-		ec.Location = namespace
 		if err != nil {
 			log.Errorf("Problem executing bundle create sandbox [%s] bind", ec.BundleName)
 			e.actionFinishedWithError(err)
@@ -80,7 +80,7 @@ func (e *executor) Bind(
 			clusterConfig.KeepNamespaceOnError,
 		)
 		if err != nil {
-			log.Errorf("Problem executing apb [%s] bind", ec.BundleName)
+			log.Errorf("Problem executing bundle [%s] bind", ec.BundleName)
 			e.actionFinishedWithError(err)
 			return
 		}

--- a/bundle/deprovision.go
+++ b/bundle/deprovision.go
@@ -17,12 +17,19 @@
 package bundle
 
 import (
+	"fmt"
+
 	"github.com/automationbroker/bundle-lib/runtime"
+	"github.com/pborman/uuid"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
 
-// Deprovision - runs the apb with the deprovision action.
+const (
+	deprovisionAction = "deprovision"
+)
+
+// Deprovision - runs the abp with the deprovision action.
 func (e *executor) Deprovision(instance *ServiceInstance) <-chan StatusMessage {
 	log.Infof("============================================================")
 	log.Infof("                      DEPROVISIONING                        ")
@@ -42,9 +49,23 @@ func (e *executor) Deprovision(instance *ServiceInstance) <-chan StatusMessage {
 			e.actionFinishedWithError(errors.New("No image field found on instance.Spec"))
 			return
 		}
-
-		// Might need to change up this interface to feed in instance ids
-		executionContext, err := e.executeApb("deprovision", instance, instance.Parameters)
+		// Create namespace name that will be used to generate a name.
+		ns := fmt.Sprintf(fmt.Sprintf("%s-%.4s-", instance.Spec.FQName, deprovisionAction))
+		// Create the podname
+		pn := fmt.Sprintf("bundle-%s", uuid.New())
+		targets := []string{instance.Context.Namespace}
+		labels := map[string]string{
+			"bundle-fqname":   instance.Spec.FQName,
+			"bundle-action":   deprovisionAction,
+			"bundle-pod-name": pn,
+		}
+		ec := runtime.ExecutionContext{
+			BundleName: pn,
+			Targets:    targets,
+			Metadata:   labels,
+			Action:     deprovisionAction,
+			Image:      instance.Spec.Image,
+		}
 		defer func() {
 			if err := e.stateManager.DeleteState(e.stateManager.Name(instance.ID.String())); err != nil {
 				log.Errorf("failed to delete state for instance %s : %v ", instance.ID.String(), err)
@@ -58,12 +79,22 @@ func (e *executor) Deprovision(instance *ServiceInstance) <-chan StatusMessage {
 				clusterConfig.KeepNamespaceOnError,
 			)
 		}()
+		serviceAccount, namespace, err := runtime.Provider.CreateSandbox(pn, ns, targets, clusterConfig.SandboxRole, labels)
 		if err != nil {
-			log.Errorf("Problem executing apb [%s] deprovision", executionContext.PodName)
+			log.Errorf("Problem executing bundle create sandbox [%s] deprovision", ec.BundleName)
 			e.actionFinishedWithError(err)
 			return
 		}
-		err = runtime.Provider.WatchRunningBundle(executionContext.PodName, executionContext.Namespace, e.updateDescription)
+		ec.Account = serviceAccount
+		ec.Location = namespace
+		ec, err = e.executeApb(ec, instance.Spec, instance.Parameters)
+		if err != nil {
+			log.Errorf("Problem executing apb [%s] bind", ec.BundleName)
+			e.actionFinishedWithError(err)
+			return
+		}
+
+		err = runtime.Provider.WatchRunningBundle(ec.BundleName, ec.Location, e.updateDescription)
 		if err != nil {
 			log.Errorf("Deprovision action failed - %v", err)
 			e.actionFinishedWithError(err)

--- a/bundle/deprovision.go
+++ b/bundle/deprovision.go
@@ -71,9 +71,9 @@ func (e *executor) Deprovision(instance *ServiceInstance) <-chan StatusMessage {
 				log.Errorf("failed to delete state for instance %s : %v ", instance.ID.String(), err)
 			}
 			runtime.Provider.DestroySandbox(
-				executionContext.PodName,
-				executionContext.Namespace,
-				executionContext.Targets,
+				ec.BundleName,
+				ec.Location,
+				ec.Targets,
 				clusterConfig.Namespace,
 				clusterConfig.KeepNamespace,
 				clusterConfig.KeepNamespaceOnError,
@@ -87,7 +87,7 @@ func (e *executor) Deprovision(instance *ServiceInstance) <-chan StatusMessage {
 		}
 		ec.Account = serviceAccount
 		ec.Location = namespace
-		ec, err = e.executeApb(ec, instance.Spec, instance.Parameters)
+		ec, err = e.executeApb(ec, instance, instance.Parameters)
 		if err != nil {
 			log.Errorf("Problem executing apb [%s] bind", ec.BundleName)
 			e.actionFinishedWithError(err)

--- a/bundle/executor.go
+++ b/bundle/executor.go
@@ -19,18 +19,11 @@ package bundle
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"os"
-	"strings"
 	"sync"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/automationbroker/bundle-lib/clients"
 	"github.com/automationbroker/bundle-lib/runtime"
-	"github.com/pborman/uuid"
 	log "github.com/sirupsen/logrus"
-	"k8s.io/api/core/v1"
 )
 
 // ExecutorAccessors - Accessors for Executor state.
@@ -156,82 +149,47 @@ func (e *executor) updateDescription(newDescription string, dashboardURL string)
 
 // executeApb - Runs an APB Action with a provided set of inputs
 func (e *executor) executeApb(
-	action string, instance *ServiceInstance, p *Parameters,
-) (ExecutionContext, error) {
-	spec := instance.Spec
-	context := instance.Context
+	exContext runtime.ExecutionContext, spec *Spec, p *Parameters,
+) (runtime.ExecutionContext, error) {
 	log.Debug("ExecutingApb:")
 	log.Debugf("name:[ %s ]", spec.FQName)
-	log.Debugf("image:[ %s ]", spec.Image)
-	log.Debugf("action:[ %s ]", action)
+	log.Debugf("image:[ %s ]", exContext.Image)
+	log.Debugf("action:[ %s ]", exContext.Action)
 	log.Debugf("pullPolicy:[ %s ]", clusterConfig.PullPolicy)
 	log.Debugf("role:[ %s ]", clusterConfig.SandboxRole)
 
-	executionContext := ExecutionContext{ProxyConfig: GetProxyConfig()}
-
-	extraVars, err := createExtraVars(context, p)
-
-	if err != nil {
-		return executionContext, err
-	}
 	// It's a critical error if a Namespace is not provided to the
 	// broker because its required to know where to execute the pods and
 	// sandbox them based on that Namespace. Should fail fast and loud,
 	// with controlled error handling.
-	if context.Namespace == "" {
-		errStr := "Namespace not found within request context. Cannot perform requested " + action
+	if exContext.Location == "" || len(exContext.Targets) == 0 {
+		errStr := "Namespace not found within request context. Cannot perform requested " + exContext.Action
 		log.Error(errStr)
-		return executionContext, errors.New(errStr)
+		return exContext, errors.New(errStr)
 	}
 
-	pullPolicy, err := checkPullPolicy(clusterConfig.PullPolicy)
+	extraVars, err := createExtraVars(exContext.Targets[0], p)
 	if err != nil {
-		return executionContext, err
+		return exContext, err
 	}
 
 	secrets := getSecrets(spec)
+	exContext.ProxyConfig = getProxyConfig()
+	exContext.Secrets = secrets
+	exContext.ExtraVars = extraVars
+	exContext.Policy = clusterConfig.PullPolicy
 
-	k8scli, err := clients.Kubernetes()
-	if err != nil {
-		return executionContext, err
-	}
-
-	executionContext.PodName = fmt.Sprintf("apb-%s", uuid.New())
-	labels := map[string]string{
-		"apb-fqname":   spec.FQName,
-		"apb-action":   action,
-		"apb-pod-name": executionContext.PodName,
-	}
-
-	e.podName = executionContext.PodName
-
-	executionContext.Targets = append(executionContext.Targets, context.Namespace)
-	// Create namespace.
-	namespace := v1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Labels:       labels,
-			GenerateName: fmt.Sprintf("%s-%.4s-", spec.FQName, action),
-		},
-	}
-	ns, err := k8scli.Client.CoreV1().Namespaces().Create(&namespace)
-	if err != nil {
-		return executionContext, err
-	}
-	//Sandbox (i.e Namespace) was created.
-	executionContext.Namespace = ns.ObjectMeta.Name
-	err = copySecretsToNamespace(executionContext, clusterConfig, k8scli, secrets)
+	err = runtime.Provider.CopySecretsToNamespace(exContext, clusterConfig.Namespace, secrets)
 	if err != nil {
 		log.Errorf("unable to copy secrets: %v to  new namespace", secrets)
-		return executionContext, err
+		return exContext, err
 	}
 
-	executionContext.ServiceAccount, err = runtime.Provider.CreateSandbox(executionContext.PodName, executionContext.Namespace, executionContext.Targets, clusterConfig.SandboxRole)
+	exContext, err = runtime.Provider.RunBundle(exContext)
 	if err != nil {
-		log.Error(err.Error())
-		return executionContext, err
+		log.Errorf("error running bundle - %v", err)
+		return exContext, err
 	}
-	volumes, volumeMounts := buildVolumeSpecs(secrets)
-	// copy any state present for this APB over to the execution ns
 	stateName := e.stateManager.Name(instance.ID.String())
 	present, err := e.stateManager.StateIsPresent(stateName)
 	if err != nil {
@@ -252,44 +210,34 @@ func (e *executor) executeApb(
 			volumeMounts = append(volumeMounts, *stateVolumeMount)
 		}
 	}
-
-	pod := &v1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:   executionContext.PodName,
-			Labels: labels,
-		},
-		Spec: v1.PodSpec{
-			Containers: []v1.Container{
-				{
-					Name:  ApbContainerName,
-					Image: spec.Image,
-					Args: []string{
-						action,
-						"--extra-vars",
-						extraVars,
-					},
-					Env:             e.createPodEnv(executionContext),
-					ImagePullPolicy: pullPolicy,
-					VolumeMounts:    volumeMounts,
-				},
-			},
-			RestartPolicy:      v1.RestartPolicyNever,
-			ServiceAccountName: executionContext.ServiceAccount,
-			Volumes:            volumes,
-		},
-	}
-
-	log.Infof(fmt.Sprintf("Creating pod %q in the %s namespace", pod.Name, executionContext.Namespace))
-	_, err = k8scli.Client.CoreV1().Pods(executionContext.Namespace).Create(pod)
-
-	return executionContext, err
+	return exContext, nil
 }
 
-// GetProxyConfig - Returns a ProxyConfig based on the presence of a proxy
+// TODO: Instead of putting namespace directly as a parameter, we should create a dictionary
+// of apb_metadata and put context and other variables in it so we don't pollute the user
+// parameter space.
+func createExtraVars(targetNamespace string, parameters *Parameters) (string, error) {
+	var paramsCopy Parameters
+	if parameters != nil && *parameters != nil {
+		paramsCopy = *parameters
+	} else {
+		paramsCopy = make(Parameters)
+	}
+
+	if targetNamespace != "" {
+		paramsCopy[NamespaceKey] = targetNamespace
+	}
+
+	paramsCopy[ClusterKey] = runtime.Provider.GetRuntime()
+	extraVars, err := json.Marshal(paramsCopy)
+	return string(extraVars), err
+}
+
+// getProxyConfig - Returns a ProxyConfig based on the presence of a proxy
 // configuration in the broker's environment. HTTP_PROXY, HTTPS_PROXY, and
 // NO_PROXY are the relevant environment variables. If no proxy is found,
 // GetProxyConfig will return nil.
-func GetProxyConfig() *ProxyConfig {
+func getProxyConfig() *runtime.ProxyConfig {
 	httpProxy, httpProxyPresent := os.LookupEnv(httpProxyEnvVar)
 	httpsProxy, httpsProxyPresent := os.LookupEnv(httpsProxyEnvVar)
 	noProxy, noProxyPresent := os.LookupEnv(noProxyEnvVar)
@@ -306,155 +254,9 @@ func GetProxyConfig() *ProxyConfig {
 		return nil
 	}
 
-	return &ProxyConfig{
+	return &runtime.ProxyConfig{
 		HTTPProxy:  httpProxy,
 		HTTPSProxy: httpsProxy,
 		NoProxy:    noProxy,
 	}
-}
-
-func buildVolumeSpecs(secrets []string) ([]v1.Volume, []v1.VolumeMount) {
-	var optional bool
-	var mountName string
-	volumes := []v1.Volume{}
-	volumeMounts := []v1.VolumeMount{}
-
-	for _, secret := range secrets {
-		mountName = "apb-" + secret
-		volumes = append(volumes, v1.Volume{
-			Name: mountName,
-			VolumeSource: v1.VolumeSource{
-				Secret: &v1.SecretVolumeSource{
-					SecretName: secret,
-					Optional:   &optional,
-					// Eventually, we can include: Items: []v1.KeyToPath here to specify specific keys in the secret
-				},
-			},
-		})
-		volumeMounts = append(volumeMounts, v1.VolumeMount{
-			Name:      mountName,
-			MountPath: "/etc/apb-secrets/" + mountName,
-			ReadOnly:  true,
-		})
-	}
-	return volumes, volumeMounts
-}
-
-// TODO: Instead of putting namespace directly as a parameter, we should create a dictionary
-// of apb_metadata and put context and other variables in it so we don't pollute the user
-// parameter space.
-func createExtraVars(context *Context, parameters *Parameters) (string, error) {
-	var paramsCopy Parameters
-	if parameters != nil && *parameters != nil {
-		paramsCopy = *parameters
-	} else {
-		paramsCopy = make(Parameters)
-	}
-
-	if context != nil {
-		paramsCopy[NamespaceKey] = context.Namespace
-	}
-
-	paramsCopy[ClusterKey] = runtime.Provider.GetRuntime()
-	extraVars, err := json.Marshal(paramsCopy)
-	return string(extraVars), err
-}
-
-func (e *executor) createPodEnv(executionContext ExecutionContext) []v1.EnvVar {
-	podEnv := []v1.EnvVar{
-		v1.EnvVar{
-			Name: "POD_NAME",
-			ValueFrom: &v1.EnvVarSource{
-				FieldRef: &v1.ObjectFieldSelector{
-					FieldPath: "metadata.name",
-				},
-			},
-		},
-		v1.EnvVar{
-			Name: "POD_NAMESPACE",
-			ValueFrom: &v1.EnvVarSource{
-				FieldRef: &v1.ObjectFieldSelector{
-					FieldPath: "metadata.namespace",
-				},
-			},
-		},
-		v1.EnvVar{
-			Name:  "BUNDLE_STATE_LOCATION",
-			Value: e.stateManager.MountLocation(),
-		},
-	}
-
-	if executionContext.ProxyConfig != nil {
-		conf := executionContext.ProxyConfig
-
-		log.Info("Proxy configuration present. Applying to APB before execution:")
-		log.Infof("%s=\"%s\"", httpProxyEnvVar, conf.HTTPProxy)
-		log.Infof("%s=\"%s\"", httpsProxyEnvVar, conf.HTTPSProxy)
-		log.Infof("%s=\"%s\"", noProxyEnvVar, conf.NoProxy)
-
-		podEnv = append(podEnv, []v1.EnvVar{
-			v1.EnvVar{
-				Name:  httpProxyEnvVar,
-				Value: conf.HTTPProxy,
-			},
-			v1.EnvVar{
-				Name:  httpsProxyEnvVar,
-				Value: conf.HTTPSProxy,
-			},
-			v1.EnvVar{
-				Name:  noProxyEnvVar,
-				Value: conf.NoProxy,
-			},
-			v1.EnvVar{
-				Name:  strings.ToLower(httpProxyEnvVar),
-				Value: conf.HTTPProxy,
-			},
-			v1.EnvVar{
-				Name:  strings.ToLower(httpsProxyEnvVar),
-				Value: conf.HTTPSProxy,
-			},
-			v1.EnvVar{
-				Name:  strings.ToLower(noProxyEnvVar),
-				Value: conf.NoProxy,
-			}}...)
-	}
-
-	return podEnv
-}
-
-// Verify PullPolicy is acceptable
-func checkPullPolicy(policy string) (v1.PullPolicy, error) {
-	n := map[string]v1.PullPolicy{
-		"always":       v1.PullAlways,
-		"never":        v1.PullNever,
-		"ifnotpresent": v1.PullIfNotPresent,
-	}
-	p := strings.ToLower(policy)
-	value, _ := n[p]
-	if value == "" {
-		return "", fmt.Errorf("ImagePullPolicy: %s not found in [%s, %s, %s,]", policy, v1.PullAlways, v1.PullNever, v1.PullIfNotPresent)
-	}
-
-	return value, nil
-}
-
-func copySecretsToNamespace(
-	executionContext ExecutionContext,
-	clusterConfig ClusterConfig,
-	k8scli *clients.KubernetesClient,
-	secrets []string,
-) error {
-	for _, secrectName := range secrets {
-		secretData, err := k8scli.Client.CoreV1().Secrets(clusterConfig.Namespace).Get(secrectName, metav1.GetOptions{})
-		if err != nil {
-			return err
-		}
-		oldMeta := secretData.ObjectMeta
-		secretData.ObjectMeta = metav1.ObjectMeta{Name: oldMeta.Name, Namespace: executionContext.Namespace, Labels: oldMeta.Labels, Annotations: oldMeta.Annotations}
-		_, err = k8scli.Client.CoreV1().Secrets(executionContext.Namespace).Create(secretData)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
 }

--- a/bundle/provision_or_update.go
+++ b/bundle/provision_or_update.go
@@ -72,7 +72,7 @@ func (e *executor) provisionOrUpdate(method executionMethod, instance *ServiceIn
 	}
 	ec.Account = serviceAccount
 	ec.Location = namespace
-	ec, err = e.executeApb(ec, instance.Spec, instance.Parameters)
+	ec, err = e.executeApb(ec, instance, instance.Parameters)
 	defer runtime.Provider.DestroySandbox(
 		ec.BundleName,
 		ec.Location,
@@ -98,9 +98,9 @@ func (e *executor) provisionOrUpdate(method executionMethod, instance *ServiceIn
 
 	// pod execution is complete so transfer state back
 	err = e.stateManager.CopyState(
-		executionContext.PodName,
+		ec.BundleName,
 		e.stateManager.Name(instance.ID.String()),
-		executionContext.Namespace,
+		ec.Location,
 		e.stateManager.MasterNamespace(),
 	)
 	if err != nil {

--- a/bundle/provision_or_update.go
+++ b/bundle/provision_or_update.go
@@ -20,11 +20,9 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/automationbroker/bundle-lib/clients"
 	"github.com/automationbroker/bundle-lib/runtime"
+	"github.com/pborman/uuid"
 	log "github.com/sirupsen/logrus"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type executionMethod string
@@ -48,36 +46,50 @@ func (e *executor) provisionOrUpdate(method executionMethod, instance *ServiceIn
 		return errors.New("No image field found on instance.Spec")
 	}
 
-	k8scli, err := clients.Kubernetes()
+	// Create namespace name that will be used to generate a name.
+	ns := fmt.Sprintf(fmt.Sprintf("%s-%.4s-", instance.Spec.FQName, method))
+	// Create the podname
+	pn := fmt.Sprintf("bundle-%s", uuid.New())
+	targets := []string{instance.Context.Namespace}
+	labels := map[string]string{
+		"bundle-fqname":   instance.Spec.FQName,
+		"bundle-action":   string(method),
+		"bundle-pod-name": pn,
+	}
+	ec := runtime.ExecutionContext{
+		BundleName: pn,
+		Targets:    targets,
+		Metadata:   labels,
+		Action:     string(method),
+		Image:      instance.Spec.Image,
+	}
+
+	serviceAccount, namespace, err := runtime.Provider.CreateSandbox(pn, ns, targets, clusterConfig.SandboxRole, labels)
 	if err != nil {
-		log.Error("Something went wrong getting kubernetes client")
+		log.Errorf("Problem executing bundle create sandbox [%s] %v", ec.BundleName, method)
+		e.actionFinishedWithError(err)
 		return err
 	}
-
-	ns := instance.Context.Namespace
-	log.Infof("Checking if namespace %s exists.", ns)
-	_, err = k8scli.Client.CoreV1().Namespaces().Get(ns, metav1.GetOptions{})
-	if err != nil {
-		return fmt.Errorf("Project %s does not exist", ns)
-	}
-
-	executionContext, err := e.executeApb(string(method), instance, instance.Parameters)
+	ec.Account = serviceAccount
+	ec.Location = namespace
+	ec, err = e.executeApb(ec, instance.Spec, instance.Parameters)
 	defer runtime.Provider.DestroySandbox(
-		executionContext.PodName,
-		executionContext.Namespace,
-		executionContext.Targets,
+		ec.BundleName,
+		ec.Location,
+		ec.Targets,
 		clusterConfig.Namespace,
 		clusterConfig.KeepNamespace,
 		clusterConfig.KeepNamespaceOnError,
 	)
 	if err != nil {
-		log.Errorf("Problem executing apb [%s] provision - err: %v ", executionContext.PodName, err)
+		log.Errorf("Problem executing apb [%s] %v", ec.BundleName, method)
+		e.actionFinishedWithError(err)
 		return err
 	}
 
 	if instance.Spec.Runtime >= 2 || !instance.Spec.Bindable {
 		log.Debugf("watching pod for serviceinstance %#v", instance.Spec)
-		err := runtime.Provider.WatchRunningBundle(executionContext.PodName, executionContext.Namespace, e.updateDescription)
+		err := runtime.Provider.WatchRunningBundle(ec.BundleName, ec.Location, e.updateDescription)
 		if err != nil {
 			log.Errorf("Provision or Update action failed - %v", err)
 			return err
@@ -100,8 +112,8 @@ func (e *executor) provisionOrUpdate(method executionMethod, instance *ServiceIn
 	}
 
 	credBytes, err := runtime.Provider.ExtractCredentials(
-		executionContext.PodName,
-		executionContext.Namespace,
+		ec.BundleName,
+		ec.Location,
 		instance.Spec.Runtime,
 	)
 	if err != nil {

--- a/bundle/types.go
+++ b/bundle/types.go
@@ -380,21 +380,3 @@ const (
 	httpsProxyEnvVar = "HTTPS_PROXY"
 	noProxyEnvVar    = "NO_PROXY"
 )
-
-// ProxyConfig - Contains a desired proxy configuration for the broker and
-// the assets that it spawns.
-type ProxyConfig struct {
-	HTTPProxy  string
-	HTTPSProxy string
-	NoProxy    string
-}
-
-// ExecutionContext - Contains the information necessary to track and clean up
-// an APB run
-type ExecutionContext struct {
-	PodName        string
-	Namespace      string
-	ServiceAccount string
-	Targets        []string
-	ProxyConfig    *ProxyConfig
-}

--- a/bundle/unbind.go
+++ b/bundle/unbind.go
@@ -69,7 +69,7 @@ func (e *executor) Unbind(
 		}
 		ec.Account = serviceAccount
 		ec.Location = namespace
-		ec, err = e.executeApb(ec, instance.Spec, parameters)
+		ec, err = e.executeApb(ec, instance, parameters)
 		defer runtime.Provider.DestroySandbox(
 			ec.BundleName,
 			ec.Location,
@@ -92,9 +92,9 @@ func (e *executor) Unbind(
 		}
 		// pod execution is complete so transfer state back
 		err = e.stateManager.CopyState(
-			executionContext.PodName,
+			ec.BundleName,
 			e.stateManager.Name(instance.ID.String()),
-			executionContext.Namespace,
+			ec.Location,
 			e.stateManager.MasterNamespace(),
 		)
 		if err != nil {

--- a/runtime/run_bundle.go
+++ b/runtime/run_bundle.go
@@ -1,0 +1,217 @@
+package runtime
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/automationbroker/bundle-lib/clients"
+	log "github.com/sirupsen/logrus"
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	// BundleContainerName - name of the container in the pod defintion
+	// Used for the default runtime.
+	BundleContainerName = "apb"
+	httpProxyEnvVar     = "HTTP_PROXY"
+	httpsProxyEnvVar    = "HTTPS_PROXY"
+	noProxyEnvVar       = "NO_PROXY"
+)
+
+// ProxyConfig - Contains a desired proxy configuration for the broker and
+// the assets that it spawns
+type ProxyConfig struct {
+	HTTPProxy  string
+	HTTPSProxy string
+	NoProxy    string
+}
+
+// ExecutionContext - Contains the information necessary to track and clean up
+// an APB run
+type ExecutionContext struct {
+	BundleName string
+	// In k8s location is the namespace that the pod is running in
+	Location string
+	// Account/user that the bundle is running as
+	Account     string
+	Targets     []string
+	Secrets     []string
+	ExtraVars   string
+	Image       string
+	Action      string
+	Policy      string
+	ProxyConfig *ProxyConfig
+	Metadata    map[string]string
+}
+
+// RunBundleFunc - method that defines how to run a bundle
+type RunBundleFunc func(ExecutionContext) (ExecutionContext, error)
+
+// CopySecretsToNamespaceFunc - copy secrets to namespace
+type CopySecretsToNamespaceFunc func(ec ExecutionContext, cn string, secrets []string) error
+
+func defaultRunBundle(extContext ExecutionContext) (ExecutionContext, error) {
+	k8scli, err := clients.Kubernetes()
+	if err != nil {
+		return extContext, err
+	}
+	pullPolicy, err := checkPullPolicy(extContext.Policy)
+	if err != nil {
+		return extContext, err
+	}
+	volumes, volumeMounts := buildVolumeSpecs(extContext.Secrets)
+
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   extContext.BundleName,
+			Labels: extContext.Metadata,
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name:  BundleContainerName,
+					Image: extContext.Image,
+					Args: []string{
+						extContext.Action,
+						"--extra-vars",
+						extContext.ExtraVars,
+					},
+					Env:             createPodEnv(extContext),
+					ImagePullPolicy: pullPolicy,
+					VolumeMounts:    volumeMounts,
+				},
+			},
+			RestartPolicy:      v1.RestartPolicyNever,
+			ServiceAccountName: extContext.Account,
+			Volumes:            volumes,
+		},
+	}
+
+	log.Infof(fmt.Sprintf("Creating pod %q in the %s namespace", pod.Name, extContext.Location))
+	_, err = k8scli.Client.CoreV1().Pods(extContext.Location).Create(pod)
+
+	return extContext, err
+}
+
+// Verify PullPolicy is acceptable
+func checkPullPolicy(policy string) (v1.PullPolicy, error) {
+	n := map[string]v1.PullPolicy{
+		"always":       v1.PullAlways,
+		"never":        v1.PullNever,
+		"ifnotpresent": v1.PullIfNotPresent,
+	}
+	p := strings.ToLower(policy)
+	value, _ := n[p]
+	if value == "" {
+		return "", fmt.Errorf("ImagePullPolicy: %s not found in [%s, %s, %s,]", policy, v1.PullAlways, v1.PullNever, v1.PullIfNotPresent)
+	}
+
+	return value, nil
+}
+
+func buildVolumeSpecs(secrets []string) ([]v1.Volume, []v1.VolumeMount) {
+	var optional bool
+	var mountName string
+	volumes := []v1.Volume{}
+	volumeMounts := []v1.VolumeMount{}
+
+	for _, secret := range secrets {
+		mountName = "apb-" + secret
+		volumes = append(volumes, v1.Volume{
+			Name: mountName,
+			VolumeSource: v1.VolumeSource{
+				Secret: &v1.SecretVolumeSource{
+					SecretName: secret,
+					Optional:   &optional,
+					// Eventually, we can include: Items: []v1.KeyToPath here to specify specific keys in the secret
+				},
+			},
+		})
+		volumeMounts = append(volumeMounts, v1.VolumeMount{
+			Name:      mountName,
+			MountPath: "/etc/apb-secrets/" + mountName,
+			ReadOnly:  true,
+		})
+	}
+	return volumes, volumeMounts
+}
+
+func createPodEnv(executionContext ExecutionContext) []v1.EnvVar {
+	podEnv := []v1.EnvVar{
+		v1.EnvVar{
+			Name: "POD_NAME",
+			ValueFrom: &v1.EnvVarSource{
+				FieldRef: &v1.ObjectFieldSelector{
+					FieldPath: "metadata.name",
+				},
+			},
+		},
+		v1.EnvVar{
+			Name: "POD_NAMESPACE",
+			ValueFrom: &v1.EnvVarSource{
+				FieldRef: &v1.ObjectFieldSelector{
+					FieldPath: "metadata.namespace",
+				},
+			},
+		},
+	}
+
+	if executionContext.ProxyConfig != nil {
+		conf := executionContext.ProxyConfig
+
+		log.Info("Proxy configuration present. Applying to APB before execution:")
+		log.Infof("%s=\"%s\"", httpProxyEnvVar, conf.HTTPProxy)
+		log.Infof("%s=\"%s\"", httpsProxyEnvVar, conf.HTTPSProxy)
+		log.Infof("%s=\"%s\"", noProxyEnvVar, conf.NoProxy)
+
+		podEnv = append(podEnv, []v1.EnvVar{
+			v1.EnvVar{
+				Name:  httpProxyEnvVar,
+				Value: conf.HTTPProxy,
+			},
+			v1.EnvVar{
+				Name:  httpsProxyEnvVar,
+				Value: conf.HTTPSProxy,
+			},
+			v1.EnvVar{
+				Name:  noProxyEnvVar,
+				Value: conf.NoProxy,
+			},
+			v1.EnvVar{
+				Name:  strings.ToLower(httpProxyEnvVar),
+				Value: conf.HTTPProxy,
+			},
+			v1.EnvVar{
+				Name:  strings.ToLower(httpsProxyEnvVar),
+				Value: conf.HTTPSProxy,
+			},
+			v1.EnvVar{
+				Name:  strings.ToLower(noProxyEnvVar),
+				Value: conf.NoProxy,
+			}}...)
+	}
+
+	return podEnv
+}
+
+// defaultCopySecretsToNamespace - copy secrets to namespace
+func defaultCopySecretsToNamespace(ec ExecutionContext, cn string, secrets []string) error {
+	k8scli, err := clients.Kubernetes()
+	if err != nil {
+		return err
+	}
+	for _, secrectName := range secrets {
+		secretData, err := k8scli.Client.CoreV1().Secrets(cn).Get(secrectName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		oldMeta := secretData.ObjectMeta
+		secretData.ObjectMeta = metav1.ObjectMeta{Name: oldMeta.Name, Namespace: ec.Location, Labels: oldMeta.Labels, Annotations: oldMeta.Annotations}
+		_, err = k8scli.Client.CoreV1().Secrets(ec.Location).Create(secretData)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/runtime/run_bundle_test.go
+++ b/runtime/run_bundle_test.go
@@ -1,0 +1,525 @@
+package runtime
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/automationbroker/bundle-lib/clients"
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestDefaultRunBundle(t *testing.T) {
+	var optionalFalse bool
+	cases := []struct {
+		name        string
+		exContext   ExecutionContext
+		expectedEX  ExecutionContext
+		expectedPod *v1.Pod
+		client      *fake.Clientset
+		shouldErr   bool
+	}{
+		{
+			name: "run bundle successfully",
+			exContext: ExecutionContext{
+				BundleName: "bundle-test",
+				Account:    "svc-acct-bundle-test",
+				Action:     "provision",
+				Location:   "test-bundle-test",
+				Targets:    []string{"target-bundle-test"},
+				Secrets:    []string{},
+				ExtraVars:  `{"apb": "test"}`,
+				Image:      "new-image",
+				Policy:     "Always",
+			},
+			expectedEX: ExecutionContext{
+				BundleName: "bundle-test",
+				Account:    "svc-acct-bundle-test",
+				Action:     "provision",
+				Location:   "test-bundle-test",
+				Targets:    []string{"target-bundle-test"},
+				Secrets:    []string{},
+				ExtraVars:  `{"apb": "test"}`,
+				Image:      "new-image",
+				Policy:     "Always",
+			},
+			expectedPod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "bundle-test",
+					Namespace: "test-bundle-test",
+					Labels:    nil,
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name:  "apb",
+							Image: "new-image",
+							Args: []string{
+								"provision",
+								"--extra-vars",
+								`{"apb": "test"}`,
+							},
+							Env: []v1.EnvVar{
+								v1.EnvVar{
+									Name: "POD_NAME",
+									ValueFrom: &v1.EnvVarSource{
+										FieldRef: &v1.ObjectFieldSelector{
+											FieldPath: "metadata.name",
+										},
+									},
+								},
+								v1.EnvVar{
+									Name: "POD_NAMESPACE",
+									ValueFrom: &v1.EnvVarSource{
+										FieldRef: &v1.ObjectFieldSelector{
+											FieldPath: "metadata.namespace",
+										},
+									},
+								},
+							},
+							ImagePullPolicy: v1.PullAlways,
+							VolumeMounts:    []v1.VolumeMount{},
+						},
+					},
+					RestartPolicy:      v1.RestartPolicyNever,
+					ServiceAccountName: "svc-acct-bundle-test",
+					Volumes:            []v1.Volume{},
+				},
+			},
+			client: fake.NewSimpleClientset(),
+		},
+		{
+			name: "run bundle successfully with a secret mounted",
+			exContext: ExecutionContext{
+				BundleName: "bundle-test",
+				Account:    "svc-acct-bundle-test",
+				Action:     "provision",
+				Location:   "test-bundle-test",
+				Targets:    []string{"target-bundle-test"},
+				Secrets:    []string{"test-secret"},
+				ExtraVars:  `{"apb": "test"}`,
+				Image:      "new-image",
+				Policy:     "Never",
+			},
+			expectedEX: ExecutionContext{
+				BundleName: "bundle-test",
+				Account:    "svc-acct-bundle-test",
+				Action:     "provision",
+				Location:   "test-bundle-test",
+				Targets:    []string{"target-bundle-test"},
+				Secrets:    []string{"test-secret"},
+				ExtraVars:  `{"apb": "test"}`,
+				Image:      "new-image",
+				Policy:     "Never",
+			},
+			expectedPod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "bundle-test",
+					Namespace: "test-bundle-test",
+					Labels:    nil,
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name:  "apb",
+							Image: "new-image",
+							Args: []string{
+								"provision",
+								"--extra-vars",
+								`{"apb": "test"}`,
+							},
+							Env: []v1.EnvVar{
+								v1.EnvVar{
+									Name: "POD_NAME",
+									ValueFrom: &v1.EnvVarSource{
+										FieldRef: &v1.ObjectFieldSelector{
+											FieldPath: "metadata.name",
+										},
+									},
+								},
+								v1.EnvVar{
+									Name: "POD_NAMESPACE",
+									ValueFrom: &v1.EnvVarSource{
+										FieldRef: &v1.ObjectFieldSelector{
+											FieldPath: "metadata.namespace",
+										},
+									},
+								},
+							},
+							ImagePullPolicy: v1.PullNever,
+							VolumeMounts: []v1.VolumeMount{
+								v1.VolumeMount{
+									Name:      "apb-test-secret",
+									MountPath: "/etc/apb-secrets/" + "apb-test-secret",
+									ReadOnly:  true,
+								},
+							},
+						},
+					},
+					RestartPolicy:      v1.RestartPolicyNever,
+					ServiceAccountName: "svc-acct-bundle-test",
+					Volumes: []v1.Volume{
+						v1.Volume{
+							Name: "apb-test-secret",
+							VolumeSource: v1.VolumeSource{
+								Secret: &v1.SecretVolumeSource{
+									SecretName: "test-secret",
+									Optional:   &optionalFalse,
+								},
+							},
+						},
+					},
+				},
+			},
+			client: fake.NewSimpleClientset(),
+		},
+		{
+			name: "run bundle successfully with proxy config",
+			exContext: ExecutionContext{
+				BundleName: "bundle-test",
+				Account:    "svc-acct-bundle-test",
+				Action:     "provision",
+				Location:   "test-bundle-test",
+				Targets:    []string{"target-bundle-test"},
+				Secrets:    []string{},
+				ExtraVars:  `{"apb": "test"}`,
+				Image:      "new-image",
+				Policy:     "IfNotPresent",
+				ProxyConfig: &ProxyConfig{
+					HTTPProxy:  "http://foo.com",
+					HTTPSProxy: "https://foo.com",
+					NoProxy:    "*.local",
+				},
+			},
+			expectedEX: ExecutionContext{
+				BundleName: "bundle-test",
+				Account:    "svc-acct-bundle-test",
+				Action:     "provision",
+				Location:   "test-bundle-test",
+				Targets:    []string{"target-bundle-test"},
+				Secrets:    []string{},
+				ExtraVars:  `{"apb": "test"}`,
+				Image:      "new-image",
+				Policy:     "IfNotPresent",
+				ProxyConfig: &ProxyConfig{
+					HTTPProxy:  "http://foo.com",
+					HTTPSProxy: "https://foo.com",
+					NoProxy:    "*.local",
+				},
+			},
+			expectedPod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "bundle-test",
+					Namespace: "test-bundle-test",
+					Labels:    nil,
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name:  "apb",
+							Image: "new-image",
+							Args: []string{
+								"provision",
+								"--extra-vars",
+								`{"apb": "test"}`,
+							},
+							Env: []v1.EnvVar{
+								v1.EnvVar{
+									Name: "POD_NAME",
+									ValueFrom: &v1.EnvVarSource{
+										FieldRef: &v1.ObjectFieldSelector{
+											FieldPath: "metadata.name",
+										},
+									},
+								},
+								v1.EnvVar{
+									Name: "POD_NAMESPACE",
+									ValueFrom: &v1.EnvVarSource{
+										FieldRef: &v1.ObjectFieldSelector{
+											FieldPath: "metadata.namespace",
+										},
+									},
+								},
+								v1.EnvVar{
+									Name:  httpProxyEnvVar,
+									Value: "http://foo.com",
+								},
+								v1.EnvVar{
+									Name:  httpsProxyEnvVar,
+									Value: "https://foo.com",
+								},
+								v1.EnvVar{
+									Name:  noProxyEnvVar,
+									Value: "*.local",
+								},
+								v1.EnvVar{
+									Name:  strings.ToLower(httpProxyEnvVar),
+									Value: "http://foo.com",
+								},
+								v1.EnvVar{
+									Name:  strings.ToLower(httpsProxyEnvVar),
+									Value: "https://foo.com",
+								},
+								v1.EnvVar{
+									Name:  strings.ToLower(noProxyEnvVar),
+									Value: "*.local",
+								},
+							},
+							ImagePullPolicy: v1.PullIfNotPresent,
+							VolumeMounts:    []v1.VolumeMount{},
+						},
+					},
+					RestartPolicy:      v1.RestartPolicyNever,
+					ServiceAccountName: "svc-acct-bundle-test",
+					Volumes:            []v1.Volume{},
+				},
+			},
+			client: fake.NewSimpleClientset(),
+		},
+		{
+			name:      "invalid k8scli",
+			client:    nil,
+			shouldErr: true,
+		},
+		{
+			name: "invalid pull policy",
+			exContext: ExecutionContext{
+				BundleName: "bundle-test",
+				Account:    "svc-acct-bundle-test",
+				Action:     "provision",
+				Location:   "test-bundle-test",
+				Targets:    []string{"target-bundle-test"},
+				Secrets:    []string{},
+				ExtraVars:  `{"apb": "test"}`,
+				Image:      "new-image",
+				Policy:     "AlwaysNotAnything",
+			},
+			client:    fake.NewSimpleClientset(),
+			shouldErr: true,
+		},
+		{
+			name: "pod already exists error",
+			exContext: ExecutionContext{
+				BundleName: "bundle-test",
+				Account:    "svc-acct-bundle-test",
+				Action:     "provision",
+				Location:   "test-bundle-test",
+				Targets:    []string{"target-bundle-test"},
+				Secrets:    []string{},
+				ExtraVars:  `{"apb": "test"}`,
+				Image:      "new-image",
+				Policy:     "Always",
+			},
+			client: fake.NewSimpleClientset(&v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "bundle-test",
+					Namespace: "test-bundle-test",
+					Labels:    nil,
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name:  "apb",
+							Image: "new-image",
+							Args: []string{
+								"provision",
+								"--extra-vars",
+								`{"apb": "test"}`,
+							},
+							Env: []v1.EnvVar{
+								v1.EnvVar{
+									Name: "POD_NAME",
+									ValueFrom: &v1.EnvVarSource{
+										FieldRef: &v1.ObjectFieldSelector{
+											FieldPath: "metadata.name",
+										},
+									},
+								},
+								v1.EnvVar{
+									Name: "POD_NAMESPACE",
+									ValueFrom: &v1.EnvVarSource{
+										FieldRef: &v1.ObjectFieldSelector{
+											FieldPath: "metadata.namespace",
+										},
+									},
+								},
+							},
+							ImagePullPolicy: v1.PullAlways,
+							VolumeMounts:    []v1.VolumeMount{},
+						},
+					},
+					RestartPolicy:      v1.RestartPolicyNever,
+					ServiceAccountName: "svc-acct-bundle-test",
+					Volumes:            []v1.Volume{},
+				},
+			}),
+			shouldErr: true,
+		},
+	}
+	k, err := clients.Kubernetes()
+	if err != nil {
+		t.Fail()
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			k.Client = tc.client
+			actualEXContext, err := defaultRunBundle(tc.exContext)
+			if err != nil {
+				if !tc.shouldErr {
+					t.Fatalf("unknown error: %v", err)
+				}
+				return
+			}
+			if tc.shouldErr {
+				t.Fatalf("expected error but did not recieve one")
+			}
+			//Get the pod that should have been created.
+			actualPod, err := k.Client.CoreV1().Pods(actualEXContext.Location).Get(actualEXContext.BundleName, metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("retrieval of the pod failed - %v", err)
+			}
+			if !reflect.DeepEqual(actualPod, tc.expectedPod) {
+				if len(actualPod.Spec.Volumes) > 0 {
+					fmt.Printf("\ngot: %#v\nexp: %#v", actualPod.Spec.Volumes[0].Secret, tc.expectedPod.Spec.Volumes[0].Secret)
+				}
+				t.Fatalf("Unexpected pod\n\nGot: %#+v\nExpected: %#+v\n", actualPod, tc.expectedPod)
+			}
+			if !reflect.DeepEqual(actualEXContext, tc.expectedEX) {
+				t.Fatalf("Unexpected ex context\n\nGot: %#+v\nExpected: %#+v\n", actualEXContext, tc.expectedEX)
+			}
+		})
+	}
+}
+
+func TestDefaultCopySecretsToNamespace(t *testing.T) {
+	cases := []struct {
+		name           string
+		ec             ExecutionContext
+		cn             string
+		secrets        []string
+		shouldError    bool
+		client         *fake.Clientset
+		expectedSecret *v1.Secret
+	}{
+		{
+			name: "copy no secrets",
+			ec: ExecutionContext{
+				Location: "test",
+			},
+			cn:      "cluster-test",
+			secrets: []string{},
+			client:  fake.NewSimpleClientset(),
+		},
+		{
+			name: "copy secret",
+			ec: ExecutionContext{
+				Location: "test",
+			},
+			cn:      "cluster-test",
+			secrets: []string{"test-secret"},
+			client: fake.NewSimpleClientset(&v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-secret",
+					Namespace: "cluster-test",
+					Labels: map[string]string{
+						"label": "value",
+					},
+					Annotations: map[string]string{
+						"annotation": "value",
+					},
+				},
+				StringData: map[string]string{"hello": "world"},
+			}),
+			expectedSecret: &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-secret",
+					Namespace: "test",
+					Labels: map[string]string{
+						"label": "value",
+					},
+					Annotations: map[string]string{
+						"annotation": "value",
+					},
+				},
+				StringData: map[string]string{"hello": "world"},
+			},
+		},
+		{
+			name: "secret not found",
+			ec: ExecutionContext{
+				Location: "test",
+			},
+			cn:          "cluster-test",
+			secrets:     []string{"test-secret"},
+			client:      fake.NewSimpleClientset(),
+			shouldError: true,
+		},
+		{
+			name: "secret already copied error",
+			ec: ExecutionContext{
+				Location: "test",
+			},
+			cn:      "cluster-test",
+			secrets: []string{"test-secret"},
+			client: fake.NewSimpleClientset(&v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-secret",
+					Namespace: "cluster-test",
+					Labels: map[string]string{
+						"label": "value",
+					},
+					Annotations: map[string]string{
+						"annotation": "value",
+					},
+				},
+				StringData: map[string]string{"hello": "world"},
+			},
+				&v1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-secret",
+						Namespace: "test",
+						Labels: map[string]string{
+							"label": "value",
+						},
+						Annotations: map[string]string{
+							"annotation": "value",
+						},
+					},
+					StringData: map[string]string{"hello": "world"},
+				}),
+			shouldError: true,
+		},
+	}
+	k, err := clients.Kubernetes()
+	if err != nil {
+		t.Fail()
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			k.Client = tc.client
+			err := defaultCopySecretsToNamespace(tc.ec, tc.cn, tc.secrets)
+			if err != nil {
+				if !tc.shouldError {
+					t.Fatalf("unknown error occurred")
+				}
+				return
+			}
+			// If nothing was supposed to be created then nothing should be in the namespace.
+			secrets, err := k.Client.CoreV1().Secrets(tc.ec.Location).List(metav1.ListOptions{})
+			if tc.expectedSecret == nil && len(secrets.Items) == 0 {
+				return
+			}
+			if tc.expectedSecret != nil && len(secrets.Items) == 0 {
+				t.Fatalf("secret was not copied")
+			}
+			if !reflect.DeepEqual(tc.expectedSecret, &secrets.Items[0]) {
+				t.Fatalf("unexpected secret:\nGot: %#v\nExp: %v", secrets.Items[0], tc.expectedSecret)
+			}
+		})
+	}
+}

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -48,6 +48,11 @@ type Configuration struct {
 	// The UpdateDescriptionFunc in the default case will call this function when the last description
 	// annotation on the running bundle is changed.
 	WatchBundle WatchRunningBundleFunc
+	// RunBundle - This is the method that will run the bundle.
+	RunBundle RunBundleFunc
+	// CopySecretsToNamespace - This is the method that is used to copy
+	// secrets from a namespace to the executionContext namespace.
+	CopySecretsToNamespace CopySecretsToNamespaceFunc
 	ExtractedCredential
 	// StateMountLocation this is where on disk the state will be stored for a bundle
 	StateMountLocation string
@@ -59,11 +64,13 @@ type Configuration struct {
 type Runtime interface {
 	ValidateRuntime() error
 	GetRuntime() string
-	CreateSandbox(string, string, []string, string) (string, error)
+	CreateSandbox(string, string, []string, string, map[string]string) (string, string, error)
 	DestroySandbox(string, string, []string, string, bool, bool)
 	ExtractCredentials(string, string, int) ([]byte, error)
 	ExtractedCredential
 	WatchRunningBundle(string, string, UpdateDescriptionFn) error
+	RunBundle(ExecutionContext) (ExecutionContext, error)
+	CopySecretsToNamespace(ExecutionContext, string, []string) error
 	StateManager
 }
 
@@ -71,11 +78,13 @@ type Runtime interface {
 type provider struct {
 	coe
 	ExtractedCredential
-	postSandboxCreate  []PostSandboxCreate
-	preSandboxCreate   []PreSandboxCreate
-	postSandboxDestroy []PostSandboxDestroy
-	preSandboxDestroy  []PreSandboxDestroy
-	watchBundle        WatchRunningBundleFunc
+	postSandboxCreate      []PostSandboxCreate
+	preSandboxCreate       []PreSandboxCreate
+	postSandboxDestroy     []PostSandboxDestroy
+	preSandboxDestroy      []PreSandboxDestroy
+	watchBundle            WatchRunningBundleFunc
+	runBundle              RunBundleFunc
+	copySecretsToNamespace CopySecretsToNamespaceFunc
 	state
 }
 
@@ -134,7 +143,32 @@ func NewRuntime(config Configuration) {
 	}
 
 	defaultStateManager := state{mountLocation: config.StateMountLocation, nsTarget: config.StateMasterNamespace}
-	p := &provider{coe: cluster, ExtractedCredential: c, state: defaultStateManager}
+	var w WatchRunningBundleFunc
+	if config.WatchBundle != nil {
+		w = config.WatchBundle
+	} else {
+		w = defaultWatchRunningBundle
+	}
+	var r RunBundleFunc
+	if config.RunBundle != nil {
+		r = config.RunBundle
+	} else {
+		r = defaultRunBundle
+	}
+	var s CopySecretsToNamespaceFunc
+	if config.CopySecretsToNamespace != nil {
+		s = config.CopySecretsToNamespace
+	} else {
+		s = defaultCopySecretsToNamespace
+	}
+
+	p := &provider{coe: cluster,
+		ExtractedCredential:    c,
+		watchBundle:            w,
+		runBundle:              r,
+		copySecretsToNamespace: s,
+		state: defaultStateManager,
+	}
 
 	if len(config.PreCreateSandboxHooks) > 0 {
 		p.preSandboxCreate = config.PreCreateSandboxHooks
@@ -204,8 +238,32 @@ func (p provider) ValidateRuntime() error {
 func (p provider) CreateSandbox(podName string,
 	namespace string,
 	targets []string,
-	apbRole string) (string, error) {
+	apbRole string,
+	metadata map[string]string,
+) (string, string, error) {
+	k8scli, err := clients.Kubernetes()
+	if err != nil {
+		return "", "", err
+	}
+	err = validateTargets(targets)
+	if err != nil {
+		return "", "", fmt.Errorf("unable to get target namespaces: %v", err)
+	}
 
+	// Create namespace.
+	ns := &apicorev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels:       metadata,
+			GenerateName: namespace,
+		},
+	}
+	ns, err = k8scli.Client.CoreV1().Namespaces().Create(ns)
+	if err != nil {
+		return "", "", err
+	}
+
+	//Sandbox (i.e Namespace) was created.
+	namespace = ns.ObjectMeta.Name
 	for i, f := range p.preSandboxCreate {
 		log.Debugf("Running pre create sandbox function: %v", i+1)
 		err := f(podName, namespace, targets, apbRole)
@@ -215,14 +273,10 @@ func (p provider) CreateSandbox(podName string,
 			log.Warningf("Pre create sandbox function failed with err: %v", err)
 		}
 	}
-	k8scli, err := clients.Kubernetes()
-	if err != nil {
-		return "", err
-	}
 
 	err = k8scli.CreateServiceAccount(podName, namespace)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 
 	log.Debugf("Trying to create apb sandbox: [ %s ], with %s permissions in namespace %s", podName, apbRole, namespace)
@@ -244,13 +298,13 @@ func (p provider) CreateSandbox(podName string,
 	// targetNamespace and namespace are the same
 	err = k8scli.CreateRoleBinding(podName, subjects, namespace, namespace, roleRef)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 
 	for _, target := range targets {
 		err = k8scli.CreateRoleBinding(podName, subjects, namespace, target, roleRef)
 		if err != nil {
-			return "", err
+			return "", "", err
 		}
 	}
 
@@ -277,7 +331,7 @@ func (p provider) CreateSandbox(podName string,
 	_, err = k8scli.Client.NetworkingV1().NetworkPolicies(targets[0]).Create(networkPolicy)
 	if err != nil {
 		log.Errorf("unable to create network policy object - %v", err)
-		return "", err
+		return "", "", err
 	}
 	log.Debugf("Successfully created network policy for pod: %v to grant network access to ns: %v", podName, targets[0])
 
@@ -293,7 +347,21 @@ func (p provider) CreateSandbox(podName string,
 		}
 	}
 
-	return podName, nil
+	return podName, namespace, nil
+}
+
+func validateTargets(targets []string) error {
+	k8scli, err := clients.Kubernetes()
+	if err != nil {
+		return err
+	}
+	for _, ns := range targets {
+		_, err = k8scli.Client.CoreV1().Namespaces().Get(ns, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // DestroySandbox - Translate the broker DestorySandbox call into cluster resource calls
@@ -390,6 +458,14 @@ func (p provider) GetRuntime() string {
 
 func (p provider) WatchRunningBundle(podName string, namespace string, updateFunc UpdateDescriptionFn) error {
 	return p.watchBundle(podName, namespace, updateFunc)
+}
+
+func (p provider) CopySecretsToNamespace(ec ExecutionContext, cn string, secrets []string) error {
+	return p.copySecretsToNamespace(ec, cn, secrets)
+}
+
+func (p provider) RunBundle(ec ExecutionContext) (ExecutionContext, error) {
+	return p.runBundle(ec)
 }
 
 func shouldDeleteNamespace(keepNamespace bool,

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -62,6 +62,18 @@ func sandboxDestroyHook(pod, ns string, targetNS []string) error {
 	return nil
 }
 
+func newRunBundle(ex ExecutionContext) (ExecutionContext, error) {
+	return ex, nil
+}
+
+func newWatchBundle(pd, ns string, u UpdateDescriptionFn) error {
+	return nil
+}
+
+func newCopySecretsToNamespace(ex ExecutionContext, cns string, targets []string) error {
+	return nil
+}
+
 func TestNewRuntime(t *testing.T) {
 	stateManager := state{nsTarget: defaultNamespace, mountLocation: defaultMountLocation}
 	testCases := []struct {
@@ -71,7 +83,6 @@ func TestNewRuntime(t *testing.T) {
 		response         *http.Response
 		expectedProvider *provider
 		shouldPanic      bool
-		dontUseDeepEqual bool
 	}{
 		{
 			name:   "New Default Openshift Runtime",
@@ -82,9 +93,12 @@ func TestNewRuntime(t *testing.T) {
 				Body:       ioutil.NopCloser(bytes.NewReader([]byte(`{"major":"3", "minor": "2"}`))),
 			},
 			expectedProvider: &provider{
-				state:               stateManager,
-				coe:                 newOpenshift(),
-				ExtractedCredential: defaultExtractedCredential{},
+				state:                  stateManager,
+				coe:                    newOpenshift(),
+				ExtractedCredential:    defaultExtractedCredential{},
+				watchBundle:            defaultWatchRunningBundle,
+				runBundle:              defaultRunBundle,
+				copySecretsToNamespace: defaultCopySecretsToNamespace,
 			},
 		},
 		{
@@ -96,9 +110,12 @@ func TestNewRuntime(t *testing.T) {
 				Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 			},
 			expectedProvider: &provider{
-				state:               stateManager,
-				coe:                 newKubernetes(),
-				ExtractedCredential: defaultExtractedCredential{},
+				state:                  stateManager,
+				coe:                    newKubernetes(),
+				ExtractedCredential:    defaultExtractedCredential{},
+				watchBundle:            defaultWatchRunningBundle,
+				runBundle:              defaultRunBundle,
+				copySecretsToNamespace: defaultCopySecretsToNamespace,
 			},
 		},
 		{
@@ -110,9 +127,12 @@ func TestNewRuntime(t *testing.T) {
 				Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 			},
 			expectedProvider: &provider{
-				state:               stateManager,
-				coe:                 newKubernetes(),
-				ExtractedCredential: defaultExtractedCredential{},
+				state:                  stateManager,
+				coe:                    newKubernetes(),
+				ExtractedCredential:    defaultExtractedCredential{},
+				watchBundle:            defaultWatchRunningBundle,
+				runBundle:              defaultRunBundle,
+				copySecretsToNamespace: defaultCopySecretsToNamespace,
 			},
 		},
 		{
@@ -124,9 +144,12 @@ func TestNewRuntime(t *testing.T) {
 				Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 			},
 			expectedProvider: &provider{
-				state:               stateManager,
-				coe:                 newKubernetes(),
-				ExtractedCredential: defaultExtractedCredential{},
+				state:                  stateManager,
+				coe:                    newKubernetes(),
+				ExtractedCredential:    defaultExtractedCredential{},
+				watchBundle:            defaultWatchRunningBundle,
+				runBundle:              defaultRunBundle,
+				copySecretsToNamespace: defaultCopySecretsToNamespace,
 			},
 		},
 		{
@@ -139,9 +162,12 @@ func TestNewRuntime(t *testing.T) {
 			},
 			shouldPanic: true,
 			expectedProvider: &provider{
-				state:               stateManager,
-				coe:                 newKubernetes(),
-				ExtractedCredential: defaultExtractedCredential{},
+				state:                  stateManager,
+				coe:                    newKubernetes(),
+				ExtractedCredential:    defaultExtractedCredential{},
+				watchBundle:            defaultWatchRunningBundle,
+				runBundle:              defaultRunBundle,
+				copySecretsToNamespace: defaultCopySecretsToNamespace,
 			},
 		},
 		{
@@ -155,9 +181,12 @@ func TestNewRuntime(t *testing.T) {
 				Body:       ioutil.NopCloser(bytes.NewReader([]byte(`{"major":"3", "minor": "2"}`))),
 			},
 			expectedProvider: &provider{
-				state:               stateManager,
-				coe:                 newOpenshift(),
-				ExtractedCredential: &mocks.ExtractedCredential{},
+				state:                  stateManager,
+				coe:                    newOpenshift(),
+				ExtractedCredential:    &mocks.ExtractedCredential{},
+				watchBundle:            defaultWatchRunningBundle,
+				runBundle:              defaultRunBundle,
+				copySecretsToNamespace: defaultCopySecretsToNamespace,
 			},
 		},
 		{
@@ -172,13 +201,15 @@ func TestNewRuntime(t *testing.T) {
 				Body:       ioutil.NopCloser(bytes.NewReader([]byte(`{"major":"3", "minor": "2"}`))),
 			},
 			expectedProvider: &provider{
-				state:               stateManager,
-				coe:                 newOpenshift(),
-				ExtractedCredential: defaultExtractedCredential{},
-				preSandboxCreate:    []PreSandboxCreate{sandboxCreateHook},
-				preSandboxDestroy:   []PreSandboxDestroy{sandboxDestroyHook},
+				state:                  stateManager,
+				coe:                    newOpenshift(),
+				ExtractedCredential:    defaultExtractedCredential{},
+				preSandboxCreate:       []PreSandboxCreate{sandboxCreateHook},
+				preSandboxDestroy:      []PreSandboxDestroy{sandboxDestroyHook},
+				watchBundle:            defaultWatchRunningBundle,
+				runBundle:              defaultRunBundle,
+				copySecretsToNamespace: defaultCopySecretsToNamespace,
 			},
-			dontUseDeepEqual: true,
 		},
 		{
 			name: "New Default Openshift Runtime with pre sandbox hooks",
@@ -192,13 +223,60 @@ func TestNewRuntime(t *testing.T) {
 				Body:       ioutil.NopCloser(bytes.NewReader([]byte(`{"major":"3", "minor": "2"}`))),
 			},
 			expectedProvider: &provider{
-				state:               stateManager,
+				state:                  stateManager,
+				coe:                    newOpenshift(),
+				ExtractedCredential:    defaultExtractedCredential{},
+				postSandboxCreate:      []PostSandboxCreate{sandboxCreateHook},
+				postSandboxDestroy:     []PostSandboxDestroy{sandboxDestroyHook},
+				watchBundle:            defaultWatchRunningBundle,
+				runBundle:              defaultRunBundle,
+				copySecretsToNamespace: defaultCopySecretsToNamespace,
+			},
+		},
+		{
+			name: "New Default Openshift Runtime with different run bundle",
+			config: Configuration{
+				RunBundle: newRunBundle,
+			},
+			client: fake.NewSimpleClientset(),
+			response: &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       ioutil.NopCloser(bytes.NewReader([]byte(`{"major":"3", "minor": "2"}`))),
+			},
+			expectedProvider: &provider{
 				coe:                 newOpenshift(),
 				ExtractedCredential: defaultExtractedCredential{},
-				postSandboxCreate:   []PostSandboxCreate{sandboxCreateHook},
-				postSandboxDestroy:  []PostSandboxDestroy{sandboxDestroyHook},
 			},
-			dontUseDeepEqual: true,
+		},
+		{
+			name: "New Default Openshift Runtime with different watch bundle",
+			config: Configuration{
+				WatchBundle: newWatchBundle,
+			},
+			client: fake.NewSimpleClientset(),
+			response: &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       ioutil.NopCloser(bytes.NewReader([]byte(`{"major":"3", "minor": "2"}`))),
+			},
+			expectedProvider: &provider{
+				coe:                 newOpenshift(),
+				ExtractedCredential: defaultExtractedCredential{},
+			},
+		},
+		{
+			name: "New Default Openshift Runtime with different copy secrets",
+			config: Configuration{
+				CopySecretsToNamespace: newCopySecretsToNamespace,
+			},
+			client: fake.NewSimpleClientset(),
+			response: &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       ioutil.NopCloser(bytes.NewReader([]byte(`{"major":"3", "minor": "2"}`))),
+			},
+			expectedProvider: &provider{
+				coe:                 newOpenshift(),
+				ExtractedCredential: defaultExtractedCredential{},
+			},
 		},
 	}
 	k, err := clients.Kubernetes()
@@ -221,30 +299,24 @@ func TestNewRuntime(t *testing.T) {
 				},
 			}
 			NewRuntime(tc.config)
-			if !tc.dontUseDeepEqual {
-				if !reflect.DeepEqual(tc.expectedProvider, Provider) {
-					t.Fatalf("invalid provider for configuration: %#+v \n\n got: %#+v \n\n exp: %#+v", tc.config, Provider, tc.expectedProvider)
-				}
-			} else {
-				p := Provider.(*provider)
-				if len(p.preSandboxCreate) != len(tc.expectedProvider.preSandboxCreate) {
-					t.Fatalf("invalid provider for configuration: %#+v \n\n got: %#+v \n\n exp: %#+v", tc.config, Provider, tc.expectedProvider)
-				}
-				if len(p.preSandboxDestroy) != len(tc.expectedProvider.preSandboxDestroy) {
-					t.Fatalf("invalid provider for configuration: %#+v \n\n got: %#+v \n\n exp: %#+v", tc.config, Provider, tc.expectedProvider)
-				}
-				if len(p.postSandboxDestroy) != len(tc.expectedProvider.postSandboxDestroy) {
-					t.Fatalf("invalid provider for configuration: %#+v \n\n got: %#+v \n\n exp: %#+v", tc.config, Provider, tc.expectedProvider)
-				}
-				if len(p.postSandboxCreate) != len(tc.expectedProvider.postSandboxCreate) {
-					t.Fatalf("invalid provider for configuration: %#+v \n\n got: %#+v \n\n exp: %#+v", tc.config, Provider, tc.expectedProvider)
-				}
-				if !reflect.DeepEqual(tc.expectedProvider.coe, p.coe) {
-					t.Fatalf("invalid provider for configuration: %#+v \n\n got: %#+v \n\n exp: %#+v", tc.config, Provider, tc.expectedProvider)
-				}
-				if !reflect.DeepEqual(tc.expectedProvider.ExtractedCredential, p.ExtractedCredential) {
-					t.Fatalf("invalid provider for configuration: %#+v \n\n got: %#+v \n\n exp: %#+v", tc.config, Provider, tc.expectedProvider)
-				}
+			p := Provider.(*provider)
+			if len(p.preSandboxCreate) != len(tc.expectedProvider.preSandboxCreate) {
+				t.Fatalf("invalid provider for configuration: %#+v \n\n got: %#+v \n\n exp: %#+v", tc.config, Provider, tc.expectedProvider)
+			}
+			if len(p.preSandboxDestroy) != len(tc.expectedProvider.preSandboxDestroy) {
+				t.Fatalf("invalid provider for configuration: %#+v \n\n got: %#+v \n\n exp: %#+v", tc.config, Provider, tc.expectedProvider)
+			}
+			if len(p.postSandboxDestroy) != len(tc.expectedProvider.postSandboxDestroy) {
+				t.Fatalf("invalid provider for configuration: %#+v \n\n got: %#+v \n\n exp: %#+v", tc.config, Provider, tc.expectedProvider)
+			}
+			if len(p.postSandboxCreate) != len(tc.expectedProvider.postSandboxCreate) {
+				t.Fatalf("invalid provider for configuration: %#+v \n\n got: %#+v \n\n exp: %#+v", tc.config, Provider, tc.expectedProvider)
+			}
+			if !reflect.DeepEqual(tc.expectedProvider.coe, p.coe) {
+				t.Fatalf("invalid provider for configuration: %#+v \n\n got: %#+v \n\n exp: %#+v", tc.config, Provider, tc.expectedProvider)
+			}
+			if !reflect.DeepEqual(tc.expectedProvider.ExtractedCredential, p.ExtractedCredential) {
+				t.Fatalf("invalid provider for configuration: %#+v \n\n got: %#+v \n\n exp: %#+v", tc.config, Provider, tc.expectedProvider)
 			}
 		})
 	}

--- a/runtime/state.go
+++ b/runtime/state.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/automationbroker/bundle-lib/clients"
 	log "github.com/sirupsen/logrus"
-	"k8s.io/api/core/v1"
 	kerror "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -27,7 +26,6 @@ type state struct {
 type StateManager interface {
 	CopyState(fromName, toName, fromNS, toNS string) error
 	DeleteState(name string) error
-	PrepareMount(name string) (*v1.VolumeMount, *v1.Volume, error)
 	StateIsPresent(name string) (bool, error)
 	Name(instanceID string) string
 	MasterNamespace() string
@@ -93,26 +91,6 @@ func (s state) StateIsPresent(stateName string) (bool, error) {
 		return false, err
 	}
 	return true, nil
-}
-
-// PrepareMount will prepare the volume definitions and mounts
-func (s state) PrepareMount(name string) (*v1.VolumeMount, *v1.Volume, error) {
-	mount := &v1.VolumeMount{
-		Name:      name,
-		MountPath: s.MountLocation(),
-		ReadOnly:  true,
-	}
-	volume := &v1.Volume{
-		Name: name,
-		VolumeSource: v1.VolumeSource{
-			ConfigMap: &v1.ConfigMapVolumeSource{
-				LocalObjectReference: v1.LocalObjectReference{
-					Name: name,
-				},
-			},
-		},
-	}
-	return mount, volume, nil
 }
 
 // DeleteState will remove the state object from the broker namespace


### PR DESCRIPTION
fixes #4 
* adding multiple layers of execution now.
* each executor method now controls create sandbox
* executor.executeBundle now does some stuff that is common
* runtime.RunBundle and Copy Secrets are overridable functions for the
runtime.