### PR TITLE
Bug 1558862 - Update openshift registry to not require auth challenges

### DIFF
--- a/registries/adapters/openshift_adapter.go
+++ b/registries/adapters/openshift_adapter.go
@@ -101,11 +101,12 @@ func (r OpenShiftAdapter) getOpenShiftAuthToken() (string, error) {
 	if strings.Index(authChallenge, "realm=\"") == -1 {
 		return "", errors.New("failed to find realm in www-authenticate header")
 	}
-	if strings.Index(authChallenge, ",") == -1 {
+	authOptions := ""
+	if strings.Index(authChallenge, ",") != -1 {
+		authOptions := strings.Split(authChallenge, ",")[1]
 		return "", errors.New("failed to find realm options in www-authenticate header")
 	}
 	authRealm := strings.Split(strings.Split(authChallenge, "realm=\"")[1], "\"")[0]
-	authOptions := strings.Split(authChallenge, ",")[1]
 	authURL := fmt.Sprintf("%v?%v", authRealm, authOptions)
 	// Replace any quotes that exist in header from authOptions
 	authURL = strings.Replace(authURL, "\"", "", -1)

--- a/registries/adapters/openshift_adapter.go
+++ b/registries/adapters/openshift_adapter.go
@@ -104,7 +104,6 @@ func (r OpenShiftAdapter) getOpenShiftAuthToken() (string, error) {
 	authOptions := ""
 	if strings.Index(authChallenge, ",") != -1 {
 		authOptions := strings.Split(authChallenge, ",")[1]
-		return "", errors.New("failed to find realm options in www-authenticate header")
 	}
 	authRealm := strings.Split(strings.Split(authChallenge, "realm=\"")[1], "\"")[0]
 	authURL := fmt.Sprintf("%v?%v", authRealm, authOptions)

--- a/registries/adapters/openshift_adapter.go
+++ b/registries/adapters/openshift_adapter.go
@@ -103,7 +103,7 @@ func (r OpenShiftAdapter) getOpenShiftAuthToken() (string, error) {
 	}
 	authOptions := ""
 	if strings.Index(authChallenge, ",") != -1 {
-		authOptions := strings.Split(authChallenge, ",")[1]
+		authOptions = strings.Split(authChallenge, ",")[1]
 	}
 	authRealm := strings.Split(strings.Split(authChallenge, "realm=\"")[1], "\"")[0]
 	authURL := fmt.Sprintf("%v?%v", authRealm, authOptions)


### PR DESCRIPTION
```
registry:
  - type: openshift
    name: aws
    url: https://registry.reg-aws.openshift.com
    user: dymurray
    pass: <token>
    images:
      - openshift3/mediawiki-apb
    white_list:
      - ".*-apb$"
```