### PR TITLE
Vendoring: Allow specifying custom adapters

### DIFF
--- a/registries/registry_test.go
+++ b/registries/registry_test.go
@@ -419,3 +419,31 @@ func TestVersionCheck(t *testing.T) {
 	// Test invalid version
 	ft.False(t, isCompatibleVersion("2.5", "3.0", "4.0"))
 }
+
+type fakeAdapter struct{}
+
+func (f fakeAdapter) GetImageNames() ([]string, error) {
+	return []string{}, nil
+}
+
+func (f fakeAdapter) FetchSpecs(names []string) ([]*apb.Spec, error) {
+	return []*apb.Spec{}, nil
+}
+
+func (f fakeAdapter) RegistryName() string {
+	return ""
+}
+
+func TestAdapterWithConfiguration(t *testing.T) {
+	c := Config{
+		Name: "nsa",
+		Type: "custom",
+	}
+
+	f := fakeAdapter{}
+
+	_, err := NewCustomRegistry(c, f, "")
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+}

--- a/registries/registry_test.go
+++ b/registries/registry_test.go
@@ -442,8 +442,10 @@ func TestAdapterWithConfiguration(t *testing.T) {
 
 	f := fakeAdapter{}
 
-	_, err := NewCustomRegistry(c, f, "")
+	reg, err := NewCustomRegistry(c, f, "")
 	if err != nil {
 		t.Fatal(err.Error())
 	}
+	ft.Equal(t, reg.adapter, f, "registry uses wrong adapter")
+	ft.Equal(t, reg.config, c, "registrying using wrong config")
 }


### PR DESCRIPTION
In order to make vendoring the Automation Broker, we need to support the ability to pass in customer registry adapters. The idea is that if you pass in an adapter, we use it instead of trying to instantiate our own. If the adapter is nil, we simply go through the block to find one we know about, otherwise we panic.