### PR TITLE
fixed the mistake of the target image naming

### DIFF
--- a/registries/adapters/openshift_adapter.go
+++ b/registries/adapters/openshift_adapter.go
@@ -27,7 +27,6 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-const openShiftName = "openshift"
 const openShiftManifestURL = "%v/v2/%v/manifests/%v"
 
 // OpenShiftAdapter - Docker Hub Adapter
@@ -43,7 +42,7 @@ type OpenShiftImage struct {
 
 // RegistryName - Retrieve the registry name
 func (r OpenShiftAdapter) RegistryName() string {
-	return openShiftName
+	return strings.TrimPrefix(r.Config.URL.String(), "https://")
 }
 
 // GetImageNames - retrieve the images

--- a/registries/adapters/openshift_adapter_test.go
+++ b/registries/adapters/openshift_adapter_test.go
@@ -28,6 +28,8 @@ import (
 )
 
 var Images = []string{"satoshi/nakamoto", "foo/bar", "paul/atreides"}
+var TestURL = "https://registry.reg-aws.openshift.com:443"
+var RegistryName = "registry.reg-aws.openshift.com:443"
 
 const OpenShiftManifestResponse = `
 {
@@ -88,6 +90,19 @@ const AuthResponse = `
   "expires_in": 300,
   "issued_at": "2018-03-27T19:54:19Z"
 }`
+
+func TestRegistryName(t *testing.T) {
+	url, err := url.Parse(TestURL)
+	if err != nil {
+		t.Fatal("Error: ", err)
+	}
+	ocpa := OpenShiftAdapter{
+		Config: Configuration{
+			URL: url,
+		},
+	}
+	ft.Equal(t, ocpa.RegistryName(), RegistryName, "the registry name returned did not match expected value")
+}
 
 func TestOpenShiftGetImageNames(t *testing.T) {
 	ocpa := OpenShiftAdapter{}

--- a/registries/adapters/openshift_adapter_test.go
+++ b/registries/adapters/openshift_adapter_test.go
@@ -89,11 +89,6 @@ const AuthResponse = `
   "issued_at": "2018-03-27T19:54:19Z"
 }`
 
-func TestOpenShiftName(t *testing.T) {
-	ocpa := OpenShiftAdapter{}
-	ft.Equal(t, ocpa.RegistryName(), "openshift", "openshift name does not match `openshift`")
-}
-
 func TestOpenShiftGetImageNames(t *testing.T) {
 	ocpa := OpenShiftAdapter{}
 	ocpa.Config.Images = Images


### PR DESCRIPTION
The correct name of the image should be `registry.reg-aws.openshift.com:443/openshift3/mediawiki-apb:v3.10`, not the `openshift/openshift3/mediawiki-apb:v3.10`. Fixed bug [1579216](https://bugzilla.redhat.com/show_bug.cgi?id=1579216).