### PR TITLE
add prune rules

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -57,5 +57,5 @@
   version = "1.3.1"
 
 [prune]
-  unused-packages = true
   go-tests = true
+  non-go = true

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -55,3 +55,7 @@
 [[constraint]]
   name = "github.com/Masterminds/semver"
   version = "1.3.1"
+
+[prune]
+  unused-packages = true
+  go-tests = true


### PR DESCRIPTION
The prune rules will reduce the size of the vendor directory:

BEFORE:
```
$ du -sh vendor/
244M    vendor/
```

AFTER:
```
$ du -sh vendor/
32M     vendor/
```
