### PR TITLE
state: use correct name for configmap mount add back env var

### DIFF
--- a/bundle/bind.go
+++ b/bundle/bind.go
@@ -97,7 +97,7 @@ func (e *executor) Bind(
 		// pod execution is complete so transfer state back
 		err = e.stateManager.CopyState(
 			ec.BundleName,
-			e.stateManager.Name(instance.ID.String()),
+			e.stateManager.MasterName(instance.ID.String()),
 			ec.Location, e.stateManager.MasterNamespace())
 		if err != nil {
 			e.actionFinishedWithError(err)

--- a/bundle/deprovision.go
+++ b/bundle/deprovision.go
@@ -76,7 +76,7 @@ func (e *executor) Deprovision(instance *ServiceInstance) <-chan StatusMessage {
 		}
 		ec, err = e.executeApb(ec, instance, instance.Parameters)
 		defer func() {
-			if err := e.stateManager.DeleteState(e.stateManager.Name(instance.ID.String())); err != nil {
+			if err := e.stateManager.DeleteState(e.stateManager.MasterName(instance.ID.String())); err != nil {
 				log.Errorf("failed to delete state for instance %s : %v ", instance.ID.String(), err)
 			}
 			runtime.Provider.DestroySandbox(

--- a/bundle/executor.go
+++ b/bundle/executor.go
@@ -184,18 +184,19 @@ func (e *executor) executeApb(
 		log.Errorf("unable to copy secrets: %v to  new namespace", secrets)
 		return exContext, err
 	}
-	stateName := e.stateManager.Name(instance.ID.String())
-	present, err := e.stateManager.StateIsPresent(stateName)
+	masterStateName := e.stateManager.MasterName(instance.ID.String())
+	present, err := e.stateManager.StateIsPresent(masterStateName)
 	if err != nil {
 		return exContext, err
 	}
 	if present {
 		log.Info("state: present for service instance copying to bundle namespace")
 		// copy from master ns to execution namespace
-		if err := e.stateManager.CopyState(stateName, exContext.BundleName, e.stateManager.MasterNamespace(), exContext.Location); err != nil {
+		if err := e.stateManager.CopyState(masterStateName, exContext.BundleName, e.stateManager.MasterNamespace(), exContext.Location); err != nil {
 			return exContext, err
 		}
-		exContext.StateName = stateName
+		exContext.StateName = exContext.BundleName
+		exContext.StateLocation = e.stateManager.MountLocation()
 	}
 
 	exContext, err = runtime.Provider.RunBundle(exContext)

--- a/bundle/provision_or_update.go
+++ b/bundle/provision_or_update.go
@@ -98,7 +98,7 @@ func (e *executor) provisionOrUpdate(method executionMethod, instance *ServiceIn
 	// pod execution is complete so transfer state back
 	err = e.stateManager.CopyState(
 		ec.BundleName,
-		e.stateManager.Name(instance.ID.String()),
+		e.stateManager.MasterName(instance.ID.String()),
 		ec.Location,
 		e.stateManager.MasterNamespace(),
 	)

--- a/bundle/unbind.go
+++ b/bundle/unbind.go
@@ -93,7 +93,7 @@ func (e *executor) Unbind(
 		// pod execution is complete so transfer state back
 		err = e.stateManager.CopyState(
 			ec.BundleName,
-			e.stateManager.Name(instance.ID.String()),
+			e.stateManager.MasterName(instance.ID.String()),
 			ec.Location,
 			e.stateManager.MasterNamespace(),
 		)

--- a/runtime/run_bundle.go
+++ b/runtime/run_bundle.go
@@ -43,7 +43,10 @@ type ExecutionContext struct {
 	Policy      string
 	ProxyConfig *ProxyConfig
 	Metadata    map[string]string
-	StateName   string
+	// StateName the name of the configmap that holds the state for the bundle
+	StateName string
+	// StateLocation the location in the pod that the state will be mounted
+	StateLocation string
 }
 
 // RunBundleFunc - method that defines how to run a bundle
@@ -173,6 +176,13 @@ func createPodEnv(executionContext ExecutionContext) []v1.EnvVar {
 				},
 			},
 		},
+	}
+
+	if executionContext.StateName != "" {
+		podEnv = append(podEnv, v1.EnvVar{
+			Name:  "BUNDLE_STATE_LOCATION",
+			Value: executionContext.StateLocation,
+		})
 	}
 
 	if executionContext.ProxyConfig != nil {

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -105,11 +105,9 @@ func NewRuntime(config Configuration) {
 		log.Error(err.Error())
 		panic(err.Error())
 	}
-
 	// Identify which cluster we're using
 	restclient := k8scli.Client.CoreV1().RESTClient()
 	body, err := restclient.Get().AbsPath("/version/openshift").Do().Raw()
-
 	var cluster coe
 	switch {
 	case err == nil:

--- a/runtime/state.go
+++ b/runtime/state.go
@@ -27,7 +27,7 @@ type StateManager interface {
 	CopyState(fromName, toName, fromNS, toNS string) error
 	DeleteState(name string) error
 	StateIsPresent(name string) (bool, error)
-	Name(instanceID string) string
+	MasterName(instanceID string) string
 	MasterNamespace() string
 	MountLocation() string
 }
@@ -72,8 +72,8 @@ func (s state) CopyState(fromName, toName, fromNS, toNS string) error {
 	return nil
 }
 
-// Name provides a consistent name for the state object
-func (s state) Name(id string) string {
+// MasterName provides a consistent name for the state object in the master namespace
+func (s state) MasterName(id string) string {
 	return fmt.Sprintf("%s-state", id)
 }
 


### PR DESCRIPTION
There was a recent change in the bundle lib that changed the name of the configmap to mount. This caused issues with the state support where the pod would fail to start if there is state found as it would attempt to mount a configmap that didn't exist
Also the env var for the state location was removed. This is used by the module currently. 

Resolves issues found in latest 0.2 branch https://github.com/openshift/ansible-service-broker/pull/946

**changes**
 - use correct configmap name in the mount
 - set the env var
 - change the name of the method that returns the master state configmap name (ie the state configmap stored in the broker NS) to be clearer
