### PR TITLE
Bug 1583577 - Target image name should add port

### DIFF
--- a/registries/adapters/partner_rhcc_adapter.go
+++ b/registries/adapters/partner_rhcc_adapter.go
@@ -176,5 +176,9 @@ func (r PartnerRhccAdapter) loadSpec(imageName string) (*apb.Spec, error) {
 		return nil, err
 	}
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %v", token))
-	return imageToSpec(req, fmt.Sprintf("%s/%s:%s", r.Config.URL.Hostname(), imageName, r.Config.Tag))
+	registryName := r.Config.URL.Hostname()
+	if r.Config.URL.Port() != "" {
+		registryName = fmt.Sprintf("%s:%s", r.Config.URL.Hostname(), r.Config.URL.Port())
+	}
+	return imageToSpec(req, fmt.Sprintf("%s/%s:%s", registryName, imageName, r.Config.Tag))
 }


### PR DESCRIPTION
The correct image name should be `registry.reg-aws.openshift.com:443/openshift3/postgresql-apb:v3.10`, not `registry.reg-aws.openshift.com/openshift3/postgresql-apb:v3.10`. We need to add the URL's port.
Details in bug [1583577](https://bugzilla.redhat.com/show_bug.cgi?id=1583577). Your comments are welcome!