### PR TITLE
adds oauth2 support to the rhcc adapter

### DIFF
--- a/registries/adapters/adapter.go
+++ b/registries/adapters/adapter.go
@@ -49,14 +49,15 @@ const BundleSpecLabel = "com.redhat.apb.spec"
 // Configuration - Adapter configuration. Contains the info that the adapter
 // would need to complete its request to the images.
 type Configuration struct {
-	URL        *url.URL
-	User       string
-	Pass       string
-	Org        string
-	Runner     string
-	Images     []string
-	Namespaces []string
-	Tag        string
+	URL           *url.URL
+	User          string
+	Pass          string
+	Org           string
+	Runner        string
+	Images        []string
+	Namespaces    []string
+	Tag           string
+	SkipVerifyTLS bool
 }
 
 type registryResponseError struct {

--- a/registries/adapters/oauth/client.go
+++ b/registries/adapters/oauth/client.go
@@ -1,0 +1,229 @@
+//
+// Copyright (c) 2018 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package oauth
+
+import (
+	"crypto/tls"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"regexp"
+	"sync"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// authResponse - holds the response data from an oauth2 token request
+type authResponse struct {
+	Token string `json:"access_token"`
+}
+
+// NewClient - creates and returns a *Client ready to use. If skipVerify is
+// true, it will skip verification of the remote TLS certificate.
+func NewClient(user, pass string, skipVerify bool, url *url.URL) *Client {
+	transport := &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: skipVerify}}
+	if skipVerify == true {
+		log.Warn("skipping verification of registry TLS certificate per adapter configuration")
+	}
+
+	return &Client{
+		user:   user,
+		pass:   pass,
+		url:    url,
+		mutex:  &sync.Mutex{},
+		client: &http.Client{Timeout: time.Second * 60, Transport: transport},
+	}
+}
+
+// Client - may be used as an HTTP client that automatically authenticates using oauth.
+type Client struct {
+	user   string
+	pass   string
+	token  string
+	mutex  *sync.Mutex
+	client *http.Client
+	url    *url.URL
+}
+
+// NewRequest - creates and returns a *http.Request assuming the GET method.
+// The base URL configured on the Client gets used with its Path component
+// replaced by the path argument. If a token is available, it is added to the
+// request automatically. "Accept: application/json" is added to all requests.
+// The caller should customize the request as necessary before using it.
+func (c *Client) NewRequest(path string) (*http.Request, error) {
+	req, err := http.NewRequest("GET", c.url.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	req.URL.Path = path
+	if c.token != "" {
+		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", c.token))
+	}
+	req.Header.Add("Accept", "application/json")
+	return req, nil
+}
+
+// Do - passes through to the underlying http.Client instance
+func (c *Client) Do(req *http.Request) (*http.Response, error) {
+	return c.client.Do(req)
+}
+
+// Getv2 - makes a GET request to the registry's /v2/ endpoint. If a 401
+// Unauthorized response is received, this method attempts to obtain an oauth
+// token and tries again with the new token. If a username and password are
+// available, they are used with Basic Auth in the request to the token
+// service. This method is goroutine-safe.
+func (c *Client) Getv2() error {
+	// lock to prevent multiple goroutines from retrieving, and especially
+	// writing, a new token at the same time
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	req, err := c.NewRequest("/v2/")
+	if err != nil {
+		return err
+	}
+	resp, err := c.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusUnauthorized:
+		h := resp.Header.Get("www-authenticate")
+		c.getToken(h)
+
+		// try the new token
+		tokenReq, err := c.NewRequest("/v2/")
+		if err != nil {
+			return err
+		}
+		tokenResp, err := c.Do(tokenReq)
+		if err != nil {
+			return err
+		}
+		defer tokenResp.Body.Close()
+
+		if tokenResp.StatusCode != http.StatusOK {
+			msg := fmt.Sprintf("Token not accepted by /v2/ - %s", tokenResp.Status)
+			log.Warn(msg)
+			return errors.New(msg)
+		}
+		log.Debug("GET /v2/ successful with new token")
+
+	case http.StatusOK:
+		if c.token == "" {
+			log.Debug("GET /v2/ successful without token")
+		} else {
+			log.Debug("GET /v2/ successful with existing token")
+		}
+
+	default:
+		msg := fmt.Sprintf("Bad response from /v2/ - %s", resp.Status)
+		log.Warn(msg)
+		return errors.New(msg)
+	}
+	return nil
+}
+
+// getToken - parses a www-authenticate header and uses the information to
+// retrieve an oauth token. The token is stored on the Client and automatically
+// added to future requests.
+func (c *Client) getToken(wwwauth string) error {
+	// compute the URL
+	u, err := parseAuthHeader(wwwauth)
+	if err != nil {
+		return err
+	}
+
+	// form the request
+	req, err := http.NewRequest("GET", u.String(), nil)
+	if err != nil {
+		log.Errorf("could not form request: %s", err.Error())
+		return err
+	}
+	if c.pass != "" {
+		log.Debug("adding basic auth to token request")
+		req.SetBasicAuth(c.user, c.pass)
+	}
+
+	// make the request
+	resp, err := c.client.Do(req)
+	if err != nil {
+		msg := fmt.Sprintf("error obtaining token: %s", err.Error())
+		log.Warn(msg)
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		msg := fmt.Sprintf("token service responded: %s", resp.Status)
+		log.Warn(msg)
+		return errors.New(msg)
+	}
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Warnf("failed to read token body: %s", err.Error())
+		return err
+	}
+
+	authResp := authResponse{}
+	err = json.Unmarshal(body, &authResp)
+	if err != nil {
+		return err
+	}
+	c.token = authResp.Token
+	log.Debugf("new token: %s", c.token)
+	return nil
+}
+
+// parseAuthHeader - parses the text from a www-authenticate header and uses it
+// to construct a url.URL that can be used to retrieve a token.
+func parseAuthHeader(value string) (*url.URL, error) {
+	rrealm, err := regexp.Compile("realm=\"([^\"]+)\"")
+	if err != nil {
+		return nil, err
+	}
+	rservice, err := regexp.Compile("service=\"([^\"]+)\"")
+	if err != nil {
+		return nil, err
+	}
+
+	rmatch := rrealm.FindStringSubmatch(value)
+	smatch := rservice.FindStringSubmatch(value)
+	if len(rmatch) != 2 || len(smatch) != 2 {
+		msg := fmt.Sprintf("Could not parse www-authenticate header: %s", value)
+		log.Warn(msg)
+		return nil, errors.New(msg)
+	}
+	realm := rmatch[1]
+	service := smatch[1]
+
+	u, err := url.Parse(realm)
+	if err != nil {
+		msg := fmt.Sprintf("realm is not a valid URL: %s", realm)
+		log.Warn(msg)
+		return nil, errors.New(msg)
+	}
+	q := u.Query()
+	q.Set("service", service)
+	u.RawQuery = q.Encode()
+	return u, nil
+}

--- a/registries/adapters/oauth/client.go
+++ b/registries/adapters/oauth/client.go
@@ -207,14 +207,12 @@ func parseAuthHeader(value string) (*url.URL, error) {
 	}
 
 	rmatch := rrealm.FindStringSubmatch(value)
-	smatch := rservice.FindStringSubmatch(value)
-	if len(rmatch) != 2 || len(smatch) != 2 {
+	if len(rmatch) != 2 {
 		msg := fmt.Sprintf("Could not parse www-authenticate header: %s", value)
 		log.Warn(msg)
 		return nil, errors.New(msg)
 	}
 	realm := rmatch[1]
-	service := smatch[1]
 
 	u, err := url.Parse(realm)
 	if err != nil {
@@ -222,8 +220,14 @@ func parseAuthHeader(value string) (*url.URL, error) {
 		log.Warn(msg)
 		return nil, errors.New(msg)
 	}
-	q := u.Query()
-	q.Set("service", service)
-	u.RawQuery = q.Encode()
+
+	smatch := rservice.FindStringSubmatch(value)
+	if len(smatch) == 2 {
+		service := smatch[1]
+		q := u.Query()
+		q.Set("service", service)
+		u.RawQuery = q.Encode()
+	}
+
 	return u, nil
 }

--- a/registries/adapters/oauth/client_test.go
+++ b/registries/adapters/oauth/client_test.go
@@ -27,12 +27,12 @@ var headerCases = map[string]string{
 	"Bearer service=\"bar\",realm=\"http://foo/a/b/c\"":  "http://foo/a/b/c?service=bar",
 	"Bearer realm=\"http://foo/a/b/c/\",service=\"bar\"": "http://foo/a/b/c/?service=bar",
 	"Bearer realm=\"https://foo\",service=\"bar\"":       "https://foo?service=bar",
+	"Bearer realm=\"http://foo/a/b/c\"":                  "http://foo/a/b/c",
 }
 
 var headerErrorCases = map[string]string{
-	"Bearer realm=\"http://foo/a/b/c\"": "Could not parse www-authenticate header:",
-	"Bearer service=\"bar\"":            "Could not parse www-authenticate header:",
-	"Bearer realm=\"\"":                 "",
+	"Bearer service=\"bar\"": "Could not parse www-authenticate header:",
+	"Bearer realm=\"\"":      "",
 }
 
 func TestParseAuthHeader(t *testing.T) {

--- a/registries/adapters/oauth/client_test.go
+++ b/registries/adapters/oauth/client_test.go
@@ -1,0 +1,80 @@
+//
+// Copyright (c) 2018 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package oauth
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+)
+
+var headerCases = map[string]string{
+	"Bearer realm=\"http://foo/a/b/c\",service=\"bar\"":  "http://foo/a/b/c?service=bar",
+	"Bearer service=\"bar\",realm=\"http://foo/a/b/c\"":  "http://foo/a/b/c?service=bar",
+	"Bearer realm=\"http://foo/a/b/c/\",service=\"bar\"": "http://foo/a/b/c/?service=bar",
+	"Bearer realm=\"https://foo\",service=\"bar\"":       "https://foo?service=bar",
+}
+
+var headerErrorCases = map[string]string{
+	"Bearer realm=\"http://foo/a/b/c\"": "Could not parse www-authenticate header:",
+	"Bearer service=\"bar\"":            "Could not parse www-authenticate header:",
+	"Bearer realm=\"\"":                 "",
+}
+
+func TestParseAuthHeader(t *testing.T) {
+	for in, out := range headerCases {
+		result, err := parseAuthHeader(in)
+		if err != nil {
+			t.Error(err.Error())
+		}
+		if result.String() != out {
+			t.Errorf("Expected %s, got %s", out, result.String())
+		}
+	}
+}
+
+func TestParseAuthHeaderErrors(t *testing.T) {
+	for in, out := range headerErrorCases {
+		_, err := parseAuthHeader(in)
+		if err == nil {
+			t.Errorf("Expected an error parsing %s", in)
+		} else if strings.HasPrefix(err.Error(), out) == false {
+			t.Errorf("Expected prefix %s, got %s", out, err.Error())
+		}
+	}
+}
+
+func TestNewRequest(t *testing.T) {
+	u, _ := url.Parse("http://automationbroker.io")
+	c := NewClient("foo", "bar", false, u)
+	c.token = "letmein"
+	req, err := c.NewRequest("/v2/")
+	if err != nil {
+		t.Error(err.Error())
+		return
+	}
+	accepth := req.Header.Get("Accept")
+	if accepth != "application/json" {
+		t.Errorf("incorrect or missing accept header: %s", accepth)
+		return
+	}
+	authh := req.Header.Get("Authorization")
+	if authh != "Bearer letmein" {
+		t.Errorf("incorrect or missing authorization header: %s", authh)
+		return
+	}
+}

--- a/registries/adapters/rhcc_adapter.go
+++ b/registries/adapters/rhcc_adapter.go
@@ -21,15 +21,24 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"net/http"
 
 	"github.com/automationbroker/bundle-lib/bundle"
+	"github.com/automationbroker/bundle-lib/registries/adapters/oauth"
 	log "github.com/sirupsen/logrus"
 )
+
+// NewRHCCAdapter - creates and returns a *RHCCAdapter ready to use.
+func NewRHCCAdapter(config Configuration) *RHCCAdapter {
+	return &RHCCAdapter{
+		Config: config,
+		client: oauth.NewClient(config.User, config.Pass, config.SkipVerifyTLS, config.URL),
+	}
+}
 
 // RHCCAdapter - Red Hat Container Catalog Registry
 type RHCCAdapter struct {
 	Config Configuration
+	client *oauth.Client
 }
 
 // RHCCImage - RHCC Registry Image that is returned from the RHCC Catalog api.
@@ -59,6 +68,7 @@ func (r RHCCAdapter) RegistryName() string {
 
 // GetImageNames - retrieve the images from the registry
 func (r RHCCAdapter) GetImageNames() ([]string, error) {
+	r.client.Getv2()
 	imageList, err := r.loadImages("\"*-apb\"")
 	if err != nil {
 		return nil, err
@@ -88,16 +98,16 @@ func (r RHCCAdapter) FetchSpecs(imageNames []string) ([]*bundle.Spec, error) {
 }
 
 // LoadImages - Get all the images for a particular query
-func (r RHCCAdapter) loadImages(Query string) (RHCCImageResponse, error) {
+func (r RHCCAdapter) loadImages(query string) (RHCCImageResponse, error) {
 	log.Debug("RHCCRegistry::LoadImages")
-	log.Debug("Using " + r.Config.URL.String() + " to source APB images using query:" + Query)
-	req, err := http.NewRequest("GET",
-		fmt.Sprintf("%v/v1/search?q=%v", r.Config.URL.String(), Query), nil)
+	req, err := r.client.NewRequest("/v1/search")
 	if err != nil {
 		return RHCCImageResponse{}, err
 	}
+	req.URL.RawQuery = fmt.Sprintf("q=%s", query)
+	log.Debug("Using " + req.URL.String() + " to source APB images ")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := r.client.Do(req)
 	if err != nil {
 		return RHCCImageResponse{}, err
 	}
@@ -123,13 +133,12 @@ func (r RHCCAdapter) loadSpec(imageName string) (*bundle.Spec, error) {
 	if r.Config.Tag == "" {
 		r.Config.Tag = "latest"
 	}
-	req, err := http.NewRequest("GET",
-		fmt.Sprintf("%v/v2/%v/manifests/%v", r.Config.URL.String(), imageName, r.Config.Tag), nil)
+	req, err := r.client.NewRequest(fmt.Sprintf("/v2/%v/manifests/%v", imageName, r.Config.Tag))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Add("Accept", "application/json")
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := r.client.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/registries/adapters/rhcc_adapter.go
+++ b/registries/adapters/rhcc_adapter.go
@@ -104,7 +104,9 @@ func (r RHCCAdapter) loadImages(query string) (RHCCImageResponse, error) {
 	if err != nil {
 		return RHCCImageResponse{}, err
 	}
-	req.URL.RawQuery = fmt.Sprintf("q=%s", query)
+	q := req.URL.Query()
+	q.Set("q", query)
+	req.URL.RawQuery = q.Encode()
 	log.Debug("Using " + req.URL.String() + " to source APB images ")
 
 	resp, err := r.client.Do(req)

--- a/registries/adapters/rhcc_adapter_test.go
+++ b/registries/adapters/rhcc_adapter_test.go
@@ -138,7 +138,7 @@ func TestGetImages(t *testing.T) {
 		t.Fatal("ERROR: ", err)
 	}
 	config := Configuration{URL: u}
-	adapter := RHCCAdapter{Config: config}
+	adapter := NewRHCCAdapter(config)
 	imageNames, err := adapter.GetImageNames()
 	ft.Equal(t, len(imageNames), 3)
 	ft.NotNil(t, imageNames)

--- a/registries/registry.go
+++ b/registries/registry.go
@@ -57,9 +57,10 @@ type Config struct {
 	Namespaces []string
 	// Fail will tell the registry that it is ok to fail the bootstrap if
 	// just this registry has failed.
-	Fail      bool     `yaml:"fail_on_error"`
-	WhiteList []string `yaml:"white_list"`
-	BlackList []string `yaml:"black_list"`
+	Fail          bool     `yaml:"fail_on_error"`
+	WhiteList     []string `yaml:"white_list"`
+	BlackList     []string `yaml:"black_list"`
+	SkipVerifyTLS bool     `yaml:"skip_verify_tls"`
 }
 
 // Validate - makes sure the registry config is valid.
@@ -195,19 +196,20 @@ func NewCustomRegistry(configuration Config, adapter adapters.Adapter, asbNamesp
 
 	if adapter == nil {
 		c := adapters.Configuration{
-			URL:        u,
-			User:       configuration.User,
-			Pass:       configuration.Pass,
-			Org:        configuration.Org,
-			Runner:     configuration.Runner,
-			Images:     configuration.Images,
-			Namespaces: configuration.Namespaces,
-			Tag:        configuration.Tag,
+			URL:           u,
+			User:          configuration.User,
+			Pass:          configuration.Pass,
+			Org:           configuration.Org,
+			Runner:        configuration.Runner,
+			Images:        configuration.Images,
+			Namespaces:    configuration.Namespaces,
+			Tag:           configuration.Tag,
+			SkipVerifyTLS: configuration.SkipVerifyTLS,
 		}
 
 		switch strings.ToLower(configuration.Type) {
 		case "rhcc":
-			adapter = &adapters.RHCCAdapter{Config: c}
+			adapter = adapters.NewRHCCAdapter(c)
 		case "dockerhub":
 			adapter = &adapters.DockerHubAdapter{Config: c}
 		case "mock":


### PR DESCRIPTION
also adds config option "skip_verify_ssl" to the rhcc adapter so that the oauth
feature can be tested against internal registries.