### PR TITLE
Add k8s authorizer

### DIFF
--- a/authorization/authorization.go
+++ b/authorization/authorization.go
@@ -1,0 +1,24 @@
+package authorization
+
+// Authorizer - authorizes users via the bundle runtime.
+type Authorizer interface {
+	Authorize(AuthorizeUser, string) (Decision, error)
+}
+
+// AuthorizeUser - an interface for a user object.
+type AuthorizeUser interface {
+	Username() string
+}
+
+// Decision - The outcome of the authorization check
+type Decision string
+
+const (
+	// DecisionAllowed - The authorizer has determined the action is allowed.
+	DecisionAllowed Decision = "allowed"
+	// DecisionDeny - The authorizer has determined the action is not allowed.
+	DecisionDeny Decision = "deny"
+	// DecisionNoOpinion - The authorizer has no opinion,
+	// this should mean the action is not allowed.
+	DecisionNoOpinion = "no opinion"
+)

--- a/authorization/k8s/authorizer.go
+++ b/authorization/k8s/authorizer.go
@@ -1,0 +1,73 @@
+package k8s
+
+import (
+	"fmt"
+
+	"github.com/automationbroker/bundle-lib/authorization"
+	"github.com/automationbroker/bundle-lib/clients"
+	authv1 "k8s.io/api/authentication/v1"
+	authorizationv1 "k8s.io/api/authorization/v1"
+)
+
+// NewAuthorizer - Create a new authorizer client.
+func NewAuthorizer(group, resource, verb string) (authorization.Authorizer, error) {
+	return k8sAuthorization{
+		resource: authorizationv1.ResourceAttributes{
+			Group:    group,
+			Resource: resource,
+			Verb:     verb,
+		},
+	}, nil
+
+}
+
+// AuthorizationUser - A user to be used by the k8s authorizer.
+type AuthorizationUser struct {
+	authv1.UserInfo
+}
+
+// Username - return the username.
+func (u AuthorizationUser) Username() string {
+	return u.UserInfo.Username
+}
+
+type k8sAuthorization struct {
+	resource authorizationv1.ResourceAttributes
+}
+
+func (a k8sAuthorization) Authorize(user authorization.AuthorizeUser, location string) (authorization.Decision, error) {
+	k, err := clients.Kubernetes()
+	if err != nil {
+		return authorization.DecisionDeny, fmt.Errorf("Unable to connect to the cluster")
+	}
+	u, ok := user.(*AuthorizationUser)
+	if !ok {
+		return authorization.DecisionDeny, fmt.Errorf("unknown user structure")
+	}
+
+	r := &a.resource
+	r.Namespace = location
+	sar := &authorizationv1.SubjectAccessReview{
+		Spec: authorizationv1.SubjectAccessReviewSpec{
+			User: u.UserInfo.Username,
+			UID:  u.UserInfo.UID,
+			//Extra:  userInfo.Extra,
+			Groups:             u.UserInfo.Groups,
+			ResourceAttributes: r,
+		},
+	}
+	sar, err = k.Client.AuthorizationV1().SubjectAccessReviews().Create(sar)
+	if err != nil {
+		return authorization.DecisionDeny, err
+	}
+	switch {
+	case sar.Status.Denied && sar.Status.Allowed:
+		return authorization.DecisionDeny, fmt.Errorf("review has both denied and allowed the request. defaulting to closed")
+	case sar.Status.Denied:
+		return authorization.DecisionDeny, nil
+	case sar.Status.Allowed:
+		return authorization.DecisionAllowed, nil
+	default:
+		return authorization.DecisionNoOpinion, nil
+	}
+}

--- a/authorization/k8s/authorizer.go
+++ b/authorization/k8s/authorizer.go
@@ -7,16 +7,22 @@ import (
 	"github.com/automationbroker/bundle-lib/clients"
 	authv1 "k8s.io/api/authentication/v1"
 	authorizationv1 "k8s.io/api/authorization/v1"
+	"k8s.io/client-go/kubernetes/typed/authorization/v1"
 )
 
 // NewAuthorizer - Create a new authorizer client.
 func NewAuthorizer(group, resource, verb string) (authorization.Authorizer, error) {
+	k, err := clients.Kubernetes()
+	if err != nil {
+		return nil, fmt.Errorf("Unable to connect to the cluster")
+	}
 	return k8sAuthorization{
 		resource: authorizationv1.ResourceAttributes{
 			Group:    group,
 			Resource: resource,
 			Verb:     verb,
 		},
+		client: k.Client.AuthorizationV1().SubjectAccessReviews(),
 	}, nil
 
 }
@@ -33,18 +39,14 @@ func (u AuthorizationUser) Username() string {
 
 type k8sAuthorization struct {
 	resource authorizationv1.ResourceAttributes
+	client   v1.SubjectAccessReviewInterface
 }
 
 func (a k8sAuthorization) Authorize(user authorization.AuthorizeUser, location string) (authorization.Decision, error) {
-	k, err := clients.Kubernetes()
-	if err != nil {
-		return authorization.DecisionDeny, fmt.Errorf("Unable to connect to the cluster")
-	}
 	u, ok := user.(*AuthorizationUser)
 	if !ok {
 		return authorization.DecisionDeny, fmt.Errorf("unknown user structure")
 	}
-
 	r := &a.resource
 	r.Namespace = location
 	sar := &authorizationv1.SubjectAccessReview{
@@ -56,7 +58,7 @@ func (a k8sAuthorization) Authorize(user authorization.AuthorizeUser, location s
 			ResourceAttributes: r,
 		},
 	}
-	sar, err = k.Client.AuthorizationV1().SubjectAccessReviews().Create(sar)
+	sar, err := a.client.Create(sar)
 	if err != nil {
 		return authorization.DecisionDeny, err
 	}

--- a/authorization/k8s/authorizer_test.go
+++ b/authorization/k8s/authorizer_test.go
@@ -1,0 +1,266 @@
+package k8s
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/automationbroker/bundle-lib/authorization"
+	"k8s.io/api/authentication/v1"
+	authorizationv1 "k8s.io/api/authorization/v1"
+	authv1 "k8s.io/client-go/kubernetes/typed/authorization/v1"
+)
+
+func TestNewAuthorizer(t *testing.T) {
+	a, err := NewAuthorizer("group", "resource", "verb")
+	if err != nil {
+		t.Fatalf("unable to get new k8s authorizer - %v", err)
+	}
+	auth, ok := a.(k8sAuthorization)
+	if !ok {
+		t.Fatal("unable to get new k8sauthorizer type")
+	}
+	resource := authorizationv1.ResourceAttributes{
+		Group:    "group",
+		Resource: "resource",
+		Verb:     "verb",
+	}
+	if !reflect.DeepEqual(resource, auth.resource) {
+		t.Fatalf("invalid resource attribute\nexpected: %#+v\nactual: %#+v", resource, auth.resource)
+	}
+}
+
+type fakeSubjectAccessReview struct {
+	SubjectAccessReview *authorizationv1.SubjectAccessReview
+}
+
+func (fsar fakeSubjectAccessReview) Create(sar *authorizationv1.SubjectAccessReview) (*authorizationv1.SubjectAccessReview, error) {
+	if !reflect.DeepEqual(fsar.SubjectAccessReview.Spec, sar.Spec) {
+		return nil, fmt.Errorf("unknown subject access review")
+	}
+	return fsar.SubjectAccessReview, nil
+}
+
+type FakeAuthUser struct {
+	v1.UserInfo
+}
+
+func (f FakeAuthUser) Username() string {
+	return f.UserInfo.Username
+}
+
+func TestSARUserInfoAuthorizer(t *testing.T) {
+	a, err := NewAuthorizer("group", "resource", "verb")
+	if err != nil {
+		t.Fatalf("unable to get new k8s authorizer - %v", err)
+	}
+	auth, ok := a.(k8sAuthorization)
+	if !ok {
+		t.Fatal("unable to get new k8sauthorizer type")
+	}
+	testCases := []struct {
+		name             string
+		sar              authv1.SubjectAccessReviewExpansion
+		user             v1.UserInfo
+		expectedDecision authorization.Decision
+		shouldError      bool
+		useFakeAuthUser  bool
+	}{
+		{
+			name: "allowed request",
+			sar: fakeSubjectAccessReview{
+				SubjectAccessReview: &authorizationv1.SubjectAccessReview{
+					Spec: authorizationv1.SubjectAccessReviewSpec{
+						User:   "foo",
+						Groups: []string{},
+						Extra:  nil,
+						ResourceAttributes: &authorizationv1.ResourceAttributes{
+							Group:     "group",
+							Resource:  "resource",
+							Verb:      "verb",
+							Namespace: "location",
+						},
+					},
+					Status: authorizationv1.SubjectAccessReviewStatus{
+						Allowed: true,
+					},
+				},
+			},
+			user: v1.UserInfo{
+				Username: "foo",
+				Groups:   []string{},
+				Extra:    nil,
+			},
+			expectedDecision: authorization.DecisionAllowed,
+		},
+		{
+			name: "no opinion request",
+			sar: fakeSubjectAccessReview{
+				SubjectAccessReview: &authorizationv1.SubjectAccessReview{
+					Spec: authorizationv1.SubjectAccessReviewSpec{
+						User:   "foo",
+						Groups: []string{},
+						Extra:  nil,
+						ResourceAttributes: &authorizationv1.ResourceAttributes{
+							Group:     "group",
+							Resource:  "resource",
+							Verb:      "verb",
+							Namespace: "location",
+						},
+					},
+					Status: authorizationv1.SubjectAccessReviewStatus{},
+				},
+			},
+			user: v1.UserInfo{
+				Username: "foo",
+				Groups:   []string{},
+				Extra:    nil,
+			},
+			expectedDecision: authorization.DecisionNoOpinion,
+		},
+		{
+			name: "denied request",
+			sar: fakeSubjectAccessReview{
+				SubjectAccessReview: &authorizationv1.SubjectAccessReview{
+					Spec: authorizationv1.SubjectAccessReviewSpec{
+						User:   "foo",
+						Groups: []string{},
+						Extra:  nil,
+						ResourceAttributes: &authorizationv1.ResourceAttributes{
+							Group:     "group",
+							Resource:  "resource",
+							Verb:      "verb",
+							Namespace: "location",
+						},
+					},
+					Status: authorizationv1.SubjectAccessReviewStatus{
+						Denied: true,
+					},
+				},
+			},
+			user: v1.UserInfo{
+				Username: "foo",
+				Groups:   []string{},
+				Extra:    map[string]v1.ExtraValue{"scope": []string{"hello"}},
+			},
+			expectedDecision: authorization.DecisionDeny,
+		},
+		{
+			name: "allowed and denied",
+			sar: fakeSubjectAccessReview{
+				SubjectAccessReview: &authorizationv1.SubjectAccessReview{
+					Spec: authorizationv1.SubjectAccessReviewSpec{
+						User:   "foo",
+						Groups: []string{},
+						Extra:  nil,
+						ResourceAttributes: &authorizationv1.ResourceAttributes{
+							Group:     "group",
+							Resource:  "resource",
+							Verb:      "verb",
+							Namespace: "location",
+						},
+					},
+					Status: authorizationv1.SubjectAccessReviewStatus{
+						Denied:  true,
+						Allowed: true,
+					},
+				},
+			},
+			user: v1.UserInfo{
+				Username: "foo",
+				Groups:   []string{},
+				Extra:    nil,
+			},
+			expectedDecision: authorization.DecisionDeny,
+			shouldError:      true,
+		},
+		{
+			name: "errored on creation",
+			sar: fakeSubjectAccessReview{
+				SubjectAccessReview: &authorizationv1.SubjectAccessReview{
+					Spec: authorizationv1.SubjectAccessReviewSpec{
+						User:   "unknown",
+						Groups: []string{},
+						Extra:  nil,
+						ResourceAttributes: &authorizationv1.ResourceAttributes{
+							Group:     "group",
+							Resource:  "resource",
+							Verb:      "verb",
+							Namespace: "location",
+						},
+					},
+					Status: authorizationv1.SubjectAccessReviewStatus{
+						Denied:  true,
+						Allowed: true,
+					},
+				},
+			},
+			user: v1.UserInfo{
+				Username: "foo",
+				Groups:   []string{},
+				Extra:    nil,
+			},
+			expectedDecision: authorization.DecisionDeny,
+			shouldError:      true,
+		},
+		{
+			name: "error unkown user.,",
+			sar: fakeSubjectAccessReview{
+				SubjectAccessReview: &authorizationv1.SubjectAccessReview{
+					Spec: authorizationv1.SubjectAccessReviewSpec{
+						User:   "unknown",
+						Groups: []string{},
+						Extra:  nil,
+						ResourceAttributes: &authorizationv1.ResourceAttributes{
+							Group:     "group",
+							Resource:  "resource",
+							Verb:      "verb",
+							Namespace: "location",
+						},
+					},
+					Status: authorizationv1.SubjectAccessReviewStatus{
+						Denied:  true,
+						Allowed: true,
+					},
+				},
+			},
+			user: v1.UserInfo{
+				Username: "foo",
+				Groups:   []string{},
+				Extra:    nil,
+			},
+			expectedDecision: authorization.DecisionDeny,
+			shouldError:      true,
+			useFakeAuthUser:  true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var au authorization.AuthorizeUser
+			if tc.useFakeAuthUser {
+				au = &FakeAuthUser{
+					UserInfo: tc.user,
+				}
+			} else {
+				au = &AuthorizationUser{
+					UserInfo: tc.user,
+				}
+			}
+			if au.Username() != tc.user.Username {
+				t.Fatalf("username should be passed through")
+			}
+			auth.client = tc.sar
+			dec, err := auth.Authorize(au, "location")
+			if err != nil {
+				if tc.shouldError {
+					return
+				}
+				t.Fatalf("unknown error occured: %v", err)
+			}
+			if dec != tc.expectedDecision {
+				t.Fatalf("expected: %v decision got: %v", tc.expectedDecision, dec)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Implementation for https://trello.com/c/fiOSsq1Q. Allows bundle lib to define a generic authorization and the decisions but also implements a specific kubernetes and openshift authorizer. 