### PR TITLE
Expose route interface from OpenShift client

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -256,7 +256,8 @@
     "image/dockerpre012",
     "image/v1",
     "network/v1",
-    "pkg/serialization"
+    "pkg/serialization",
+    "route/v1"
   ]
   revision = "0d921e363e951d89f583292c60d013c318df64dc"
   version = "v3.9.0"
@@ -272,7 +273,12 @@
     "image/clientset/versioned/scheme",
     "image/clientset/versioned/typed/image/v1",
     "network/clientset/versioned/scheme",
-    "network/clientset/versioned/typed/network/v1"
+    "network/clientset/versioned/typed/network/v1",
+    "route/clientset/versioned",
+    "route/clientset/versioned/fake",
+    "route/clientset/versioned/scheme",
+    "route/clientset/versioned/typed/route/v1",
+    "route/clientset/versioned/typed/route/v1/fake"
   ]
   revision = "1fa528d3be060e4c7178eb69e76d37cf7e699e3c"
   version = "v3.9.0"
@@ -590,6 +596,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "cde9ddc1b5b8d7baabd3c567b00aeebca38cfaa3b0ee1094ce3d547d62946b17"
+  inputs-digest = "571f41c5232c04747e6a25fb851aa887d33d400ed1c0b39c1b2a10ba346196cb"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/clients/openshift.go
+++ b/clients/openshift.go
@@ -23,7 +23,6 @@ import (
 	authoapi "github.com/openshift/api/authorization/v1"
 	"github.com/openshift/api/image/v1"
 	networkoapi "github.com/openshift/api/network/v1"
-	routeoapi "github.com/openshift/api/route/v1"
 	authv1 "github.com/openshift/client-go/authorization/clientset/versioned/typed/authorization/v1"
 	imagev1 "github.com/openshift/client-go/image/clientset/versioned/typed/image/v1"
 	networkv1 "github.com/openshift/client-go/network/clientset/versioned/typed/network/v1"
@@ -183,7 +182,7 @@ func (o OpenshiftClient) IsolateNamespacesNetworks(netns *networkoapi.NetNamespa
 	return result, nil
 }
 
-// ListNamespacedRoutes - Get List of Routes in Namespace.
-func (o OpenshiftClient) ListNamespacedRoutes(ns string) (*routeoapi.RouteList, error) {
-	return o.routeClient.Routes(ns).List(metav1.ListOptions{})
+// Route - Returns a V1Route Interface
+func (o OpenshiftClient) Route() *routev1.RouteV1Interface {
+	return &o.routeClient
 }

--- a/clients/openshift.go
+++ b/clients/openshift.go
@@ -183,6 +183,6 @@ func (o OpenshiftClient) IsolateNamespacesNetworks(netns *networkoapi.NetNamespa
 }
 
 // Route - Returns a V1Route Interface
-func (o OpenshiftClient) Route() *routev1.RouteV1Interface {
-	return &o.routeClient
+func (o OpenshiftClient) Route() routev1.RouteV1Interface {
+	return o.routeClient
 }

--- a/clients/openshift_test.go
+++ b/clients/openshift_test.go
@@ -6,10 +6,42 @@ import (
 	"testing"
 
 	authapi "github.com/openshift/api/authorization/v1"
+	routeapi "github.com/openshift/api/route/v1"
 	authfake "github.com/openshift/client-go/authorization/clientset/versioned/fake"
+	routefake "github.com/openshift/client-go/route/clientset/versioned/fake"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgotesting "k8s.io/client-go/testing"
 )
+
+func TestRoute(t *testing.T) {
+	testCases := []struct {
+		name      string
+		host      string
+		route     *routeapi.Route
+		namespace string
+	}{
+		{
+			name: "get route",
+			route: &routeapi.Route{
+				Spec: routeapi.RouteSpec{
+					Host: "foo-route.example.com",
+				},
+				Status: routeapi.RouteStatus{},
+			},
+			namespace: "ns1",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := routefake.NewSimpleClientset(tc.route)
+			if c.Route().Routes(tc.namespace) == nil {
+				t.Fail()
+			}
+			return
+		})
+	}
+}
 
 func TestOpenshiftSubjectRulesReview(t *testing.T) {
 	o, err := Openshift()


### PR DESCRIPTION
This gives us the ability to get a RouteList object given a namespace. This is useful for `sbcli` since we need to get the broker's route.