### PR TITLE
Remove printing of blacklisted/whitelisted bundles from goroutine

### DIFF
--- a/registries/registry.go
+++ b/registries/registry.go
@@ -112,7 +112,7 @@ func (r Registry) LoadSpecs() ([]*bundle.Spec, int, error) {
 	log.Debugf("Filter applied against registry: %s", r.config.Name)
 
 	if len(validNames) != 0 {
-		log.Debugf("APBs passing white/blacklist filter:")
+		log.Debugf("Bundles passing white/blacklist filter:")
 		for _, name := range validNames {
 			log.Debugf("-> %s", name)
 		}
@@ -120,7 +120,7 @@ func (r Registry) LoadSpecs() ([]*bundle.Spec, int, error) {
 
 	if len(filteredNames) != 0 {
 		var buffer bytes.Buffer
-		buffer.WriteString("APBs filtered by white/blacklist filter:")
+		buffer.WriteString("Bundles filtered by white/blacklist filter:")
 		for _, name := range filteredNames {
 			buffer.WriteString(fmt.Sprintf("-> %s", name))
 		}

--- a/registries/registry.go
+++ b/registries/registry.go
@@ -119,14 +119,12 @@ func (r Registry) LoadSpecs() ([]*bundle.Spec, int, error) {
 	}
 
 	if len(filteredNames) != 0 {
-		go func() {
-			var buffer bytes.Buffer
-			buffer.WriteString("APBs filtered by white/blacklist filter:")
-			for _, name := range filteredNames {
-				buffer.WriteString(fmt.Sprintf("-> %s", name))
-			}
-			log.Infof(buffer.String())
-		}()
+		var buffer bytes.Buffer
+		buffer.WriteString("APBs filtered by white/blacklist filter:")
+		for _, name := range filteredNames {
+			buffer.WriteString(fmt.Sprintf("-> %s", name))
+		}
+		log.Infof(buffer.String())
 	}
 
 	// Debug output filtered out names.


### PR DESCRIPTION
Fixes https://github.com/automationbroker/sbcli/issues/68

 - Remove printing of whitelist/blacklist from goroutine
 - Change "APBs" to "Bundles" in registry.go

Was having issues with displaying a list of specs from known registries in `sbcli`. At random, I'd see the "APBs filtered by white/blacklist filter" message showing up in the middle of the results like so:

```
$ sbcli bundle list
Getting specs for registry: [docker]
INFO == REGISTRY CX ==                            
INFO Name: docker                                 
INFO Type: local_openshift                        
INFO Url: docker.io                               
INFO Validating specs...                          
INFO All specs passed validation!                 
INFO Registry docker has 0 bundles available from 18 images scanned 
 BUNDLE     IMAGE     REGISTRY 
 ------ -+-INFO APBs filtered by white/blacklist filter:-> openshift/httpd-> openshift/jenkins-> openshift/mariadb-> openshift/mongodb-> openshift/mysql-> openshift/nginx-> openshift/nodejs-> openshift/perl-> openshift/php-> openshift/postgresql-> openshift/python-> openshift/redis-> openshift/ruby-> myproject/apb-base-> myproject/foo3-> myproject/mssql-server-linux-> myproject/st1-> myproject/st4 
 ----- -+- --------  
```

Removing the goroutine that prints whitelist/blacklisted bundles from `registry.go` resolved the issue for me. Now looks like this: 

```
$ sbcli bundle list
Getting specs for registry: [docker]
INFO == REGISTRY CX ==                            
INFO Name: docker                                 
INFO Type: local_openshift                        
INFO Url: docker.io                               
WARN Failed to create a InternalClientSet: unable to load in-cluster configuration,  
INFO APBs filtered by white/blacklist filter:-> openshift/httpd-> openshift/jenkins-> openshift/mariadb-> openshift/mongodb-> openshift/mysql-> openshift/nginx-> openshift/nodejs-> openshift/perl-> openshift/php-> openshift/postgresql-> openshift/python-> openshift/redis-> openshift/ruby-> myproject/apb-base-> myproject/foo3-> myproject/mssql-server-linux-> myproject/st1-> myproject/st4 
INFO Validating specs...                          
INFO All specs passed validation!                 
INFO Registry docker has 0 bundles available from 18 images scanned 

 BUNDLE     IMAGE     REGISTRY 
 ------ -+- ----- -+- --------  
```

