### PR TITLE
random deprovision error about DestroySandbox

### DIFF
--- a/bundle/deprovision_test.go
+++ b/bundle/deprovision_test.go
@@ -326,6 +326,7 @@ func TestDeprovision(t *testing.T) {
 			},
 			addExpectations: func(rt *runtime.MockRuntime, e Executor) {
 				rt.On("CreateSandbox", mock.Anything, "target", []string{"target"}, mock.Anything, mock.Anything).Return("", "", fmt.Errorf("unknown error"))
+				rt.On("DestroySandbox", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 			},
 			validateMessage: func(m []StatusMessage) bool {
 				if len(m) != 2 {


### PR DESCRIPTION
looking through the test this was the only test that had a mock for
CreateSandbox but did not have an expectation for DestroySandbox.