### PR TITLE
Registry tests

### DIFF
--- a/registries/registry_test.go
+++ b/registries/registry_test.go
@@ -318,19 +318,38 @@ func TestRegistryLoadSpecsBadRuntime(t *testing.T) {
 }
 
 func TestFail(t *testing.T) {
-	r := setUp()
-	r.config.Fail = true
+	inputerr := fmt.Errorf("sample test err")
 
-	fail := r.Fail(fmt.Errorf("new error"))
-	assert.True(t, fail)
-}
+	testCases := []struct {
+		name     string
+		r        Registry
+		expected bool
+	}{
+		{
+			name: "fail should return true",
+			r: Registry{
+				config: Config{
+					Fail: true,
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "fail should return false",
+			r: Registry{
+				config: Config{
+					Fail: false,
+				},
+			},
+			expected: false,
+		},
+	}
 
-func TestFailIsFalse(t *testing.T) {
-	r := setUp()
-	r.config.Fail = false
-
-	fail := r.Fail(fmt.Errorf("new error"))
-	assert.False(t, fail)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.r.Fail(inputerr))
+		})
+	}
 }
 
 func TestNewRegistryRHCC(t *testing.T) {

--- a/registries/registry_test.go
+++ b/registries/registry_test.go
@@ -417,6 +417,61 @@ func TestNewRegistry(t *testing.T) {
 			},
 			expectederr: true,
 		},
+		{
+			name: "local openshift registry",
+			c: Config{
+				Type: "local_openshift",
+				Name: "local_openshift",
+			},
+			validate: func(reg Registry) bool {
+				_, ok := reg.adapter.(*adapters.LocalOpenShiftAdapter)
+				return ok
+			},
+		},
+		{
+			name: "helm registry",
+			c: Config{
+				Type: "helm",
+				Name: "helm",
+			},
+			validate: func(reg Registry) bool {
+				_, ok := reg.adapter.(*adapters.HelmAdapter)
+				return ok
+			},
+		},
+		{
+			name: "openshift registry",
+			c: Config{
+				Type: "openshift",
+				Name: "openshift",
+			},
+			validate: func(reg Registry) bool {
+				_, ok := reg.adapter.(*adapters.OpenShiftAdapter)
+				return ok
+			},
+		},
+		{
+			name: "partner rhcc registry",
+			c: Config{
+				Type: "partner_rhcc",
+				Name: "partner_rhcc",
+			},
+			validate: func(reg Registry) bool {
+				_, ok := reg.adapter.(*adapters.PartnerRhccAdapter)
+				return ok
+			},
+		},
+		{
+			name: "apiv2 registry",
+			c: Config{
+				Type: "apiv2",
+				Name: "genericapiv2",
+			},
+			validate: func(reg Registry) bool {
+				_, ok := reg.adapter.(*adapters.APIV2Adapter)
+				return ok
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/registries/registry_test.go
+++ b/registries/registry_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/automationbroker/bundle-lib/bundle"
 	"github.com/automationbroker/bundle-lib/registries/adapters"
-	ft "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 var SpecTags = []string{"latest", "old-release"}
@@ -264,57 +264,57 @@ func TestRegistryLoadSpecsNoError(t *testing.T) {
 	r := setUp()
 	specs, numImages, err := r.LoadSpecs()
 	if err != nil {
-		ft.True(t, false)
+		assert.True(t, false)
 	}
-	ft.True(t, a.Called["GetImageNames"])
-	ft.True(t, a.Called["FetchSpecs"])
-	ft.Equal(t, numImages, 2)
-	ft.Equal(t, len(specs), 1)
-	ft.Equal(t, specs[0], &s)
+	assert.True(t, a.Called["GetImageNames"])
+	assert.True(t, a.Called["FetchSpecs"])
+	assert.Equal(t, numImages, 2)
+	assert.Equal(t, len(specs), 1)
+	assert.Equal(t, specs[0], &s)
 }
 
 func TestRegistryLoadSpecsNoPlans(t *testing.T) {
 	r := setUpNoPlans()
 	specs, _, err := r.LoadSpecs()
 	if err != nil {
-		ft.True(t, false)
+		assert.True(t, false)
 	}
-	ft.True(t, a.Called["GetImageNames"])
-	ft.True(t, a.Called["FetchSpecs"])
-	ft.Equal(t, len(specs), 0)
+	assert.True(t, a.Called["GetImageNames"])
+	assert.True(t, a.Called["FetchSpecs"])
+	assert.Equal(t, len(specs), 0)
 }
 
 func TestRegistryLoadSpecsNoVersion(t *testing.T) {
 	r := setUpNoVersion()
 	specs, _, err := r.LoadSpecs()
 	if err != nil {
-		ft.True(t, false)
+		assert.True(t, false)
 	}
-	ft.True(t, a.Called["GetImageNames"])
-	ft.True(t, a.Called["FetchSpecs"])
-	ft.Equal(t, len(specs), 0)
+	assert.True(t, a.Called["GetImageNames"])
+	assert.True(t, a.Called["FetchSpecs"])
+	assert.Equal(t, len(specs), 0)
 }
 
 func TestRegistryLoadSpecsBadVersion(t *testing.T) {
 	r := setUpBadVersion()
 	specs, _, err := r.LoadSpecs()
 	if err != nil {
-		ft.True(t, false)
+		assert.True(t, false)
 	}
-	ft.True(t, a.Called["GetImageNames"])
-	ft.True(t, a.Called["FetchSpecs"])
-	ft.Equal(t, len(specs), 0)
+	assert.True(t, a.Called["GetImageNames"])
+	assert.True(t, a.Called["FetchSpecs"])
+	assert.Equal(t, len(specs), 0)
 }
 
 func TestRegistryLoadSpecsBadRuntime(t *testing.T) {
 	r := setUpBadRuntime()
 	specs, _, err := r.LoadSpecs()
 	if err != nil {
-		ft.True(t, false)
+		assert.True(t, false)
 	}
-	ft.True(t, a.Called["GetImageNames"])
-	ft.True(t, a.Called["FetchSpecs"])
-	ft.Equal(t, len(specs), 0)
+	assert.True(t, a.Called["GetImageNames"])
+	assert.True(t, a.Called["FetchSpecs"])
+	assert.Equal(t, len(specs), 0)
 }
 
 func TestFail(t *testing.T) {
@@ -322,7 +322,7 @@ func TestFail(t *testing.T) {
 	r.config.Fail = true
 
 	fail := r.Fail(fmt.Errorf("new error"))
-	ft.True(t, fail)
+	assert.True(t, fail)
 }
 
 func TestFailIsFalse(t *testing.T) {
@@ -330,7 +330,7 @@ func TestFailIsFalse(t *testing.T) {
 	r.config.Fail = false
 
 	fail := r.Fail(fmt.Errorf("new error"))
-	ft.False(t, fail)
+	assert.False(t, fail)
 }
 
 func TestNewRegistryRHCC(t *testing.T) {
@@ -340,10 +340,10 @@ func TestNewRegistryRHCC(t *testing.T) {
 	}
 	reg, err := NewRegistry(c, "")
 	if err != nil {
-		ft.True(t, false)
+		assert.True(t, false)
 	}
 	_, ok := reg.adapter.(*adapters.RHCCAdapter)
-	ft.True(t, ok)
+	assert.True(t, ok)
 }
 
 func TestNewRegistryDockerHub(t *testing.T) {
@@ -356,10 +356,10 @@ func TestNewRegistryDockerHub(t *testing.T) {
 	}
 	reg, err := NewRegistry(c, "")
 	if err != nil {
-		ft.True(t, false)
+		assert.True(t, false)
 	}
 	_, ok := reg.adapter.(*adapters.DockerHubAdapter)
-	ft.True(t, ok)
+	assert.True(t, ok)
 }
 
 func TestNewRegistryMock(t *testing.T) {
@@ -370,10 +370,10 @@ func TestNewRegistryMock(t *testing.T) {
 
 	reg, err := NewRegistry(c, "")
 	if err != nil {
-		ft.True(t, false)
+		assert.True(t, false)
 	}
 	_, ok := reg.adapter.(*adapters.MockAdapter)
-	ft.True(t, ok)
+	assert.True(t, ok)
 }
 
 func TestUnknownType(t *testing.T) {
@@ -393,7 +393,7 @@ func TestValidateName(t *testing.T) {
 	}
 	_, err := NewRegistry(c, "")
 	if err == nil {
-		ft.True(t, false)
+		assert.True(t, false)
 	}
 }
 
@@ -423,6 +423,6 @@ func TestAdapterWithConfiguration(t *testing.T) {
 	if err != nil {
 		t.Fatal(err.Error())
 	}
-	ft.Equal(t, reg.adapter, f, "registry uses wrong adapter")
-	ft.Equal(t, reg.config, c, "registrying using wrong config")
+	assert.Equal(t, reg.adapter, f, "registry uses wrong adapter")
+	assert.Equal(t, reg.config, c, "registrying using wrong config")
 }

--- a/registries/registry_test.go
+++ b/registries/registry_test.go
@@ -387,6 +387,39 @@ func TestUnknownType(t *testing.T) {
 	}
 }
 
+func TestRegistryName(t *testing.T) {
+	testCases := []struct {
+		name     string
+		r        Registry
+		expected string
+	}{
+		{
+			name: "registry name",
+			r: Registry{
+				config: Config{
+					Name: "registryname",
+				},
+			},
+			expected: "registryname",
+		},
+		{
+			name: "empty name",
+			r: Registry{
+				config: Config{
+					Name: "",
+				},
+			},
+			expected: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.r.RegistryName())
+		})
+	}
+}
+
 func TestValidate(t *testing.T) {
 
 	testCases := []struct {

--- a/registries/registry_test.go
+++ b/registries/registry_test.go
@@ -116,6 +116,19 @@ var s = bundle.Spec{
 	Plans:       []bundle.Plan{p},
 }
 
+var dupePlansSpec = bundle.Spec{
+	Version:     SpecVersion,
+	Runtime:     SpecRuntime,
+	ID:          SpecID,
+	Description: SpecDescription,
+	FQName:      SpecName,
+	Image:       SpecImage,
+	Tags:        SpecTags,
+	Bindable:    SpecBindable,
+	Async:       SpecAsync,
+	Plans:       []bundle.Plan{p, p},
+}
+
 var noPlansSpec = bundle.Spec{
 	Version:     SpecVersion,
 	Runtime:     SpecRuntime,
@@ -206,6 +219,21 @@ func setUp() Registry {
 	return r
 }
 
+func setUpDupePlans() Registry {
+	a = &TestingAdapter{
+		Name:   "dupeadapter",
+		Images: []string{"image1-bundle", "image2"},
+		Specs:  []*bundle.Spec{&dupePlansSpec},
+		Called: map[string]bool{},
+	}
+	filter := Filter{}
+	c := Config{}
+	r = Registry{config: c,
+		adapter: a,
+		filter:  filter}
+	return r
+}
+
 func setUpNoPlans() Registry {
 	a = &TestingAdapter{
 		Name:   "testing",
@@ -282,6 +310,16 @@ func TestRegistryLoadSpecs(t *testing.T) {
 				assert.Equal(t, specs[0], &s)
 				return true
 			},
+		},
+		{
+			name: "load specs with duplicate plans",
+			r:    setUpDupePlans(),
+			validate: func(specs []*bundle.Spec, images int, err error) bool {
+				assert.Equal(t, images, 2)
+				assert.Equal(t, len(specs), 0)
+				return true
+			},
+			expectederr: false,
 		},
 		{
 			name: "load specs no plans",

--- a/registries/registry_test.go
+++ b/registries/registry_test.go
@@ -387,13 +387,115 @@ func TestUnknownType(t *testing.T) {
 	}
 }
 
-func TestValidateName(t *testing.T) {
-	c := Config{
-		Type: "dockerhub",
+func TestValidate(t *testing.T) {
+
+	testCases := []struct {
+		name     string
+		c        Config
+		expected bool
+	}{
+		{
+			name:     "empty name",
+			c:        Config{Name: ""},
+			expected: false,
+		},
+		{
+			name: "valid name, empty authtype and authname",
+			c: Config{
+				Name:     "daname",
+				AuthName: "",
+				AuthType: "",
+			},
+			expected: true,
+		},
+		{
+			name: "valid name, empty authtype, non-empty authname",
+			c: Config{
+				Name:     "daname",
+				AuthName: "shouldfail",
+				AuthType: "",
+			},
+			expected: false,
+		},
+		{
+			name: "valid name, file, empty authname",
+			c: Config{
+				Name:     "daname",
+				AuthName: "",
+				AuthType: "file",
+			},
+			expected: false,
+		},
+		{
+			name: "valid name, file, non-empty authname",
+			c: Config{
+				Name:     "daname",
+				AuthName: "non-empty",
+				AuthType: "file",
+			},
+			expected: true,
+		},
+		{
+			name: "valid name, secret, empty authname",
+			c: Config{
+				Name:     "daname",
+				AuthName: "",
+				AuthType: "secret",
+			},
+			expected: false,
+		},
+		{
+			name: "valid name, secret, non-empty authname",
+			c: Config{
+				Name:     "daname",
+				AuthName: "non-empty",
+				AuthType: "secret",
+			},
+			expected: true,
+		},
+		{
+			name: "valid name, config, without user",
+			c: Config{
+				Name:     "daname",
+				User:     "",
+				AuthType: "config",
+			},
+			expected: false,
+		},
+		{
+			name: "valid name, config, without pass",
+			c: Config{
+				Name:     "daname",
+				User:     "user",
+				Pass:     "",
+				AuthType: "config",
+			},
+			expected: false,
+		},
+		{
+			name: "valid name, config, user, pass",
+			c: Config{
+				Name:     "daname",
+				User:     "user",
+				Pass:     "$3cr3+",
+				AuthType: "config",
+			},
+			expected: true,
+		},
+		{
+			name: "valid name, unknown",
+			c: Config{
+				Name:     "daname",
+				AuthType: "unknown",
+			},
+			expected: false,
+		},
 	}
-	_, err := NewRegistry(c, "")
-	if err == nil {
-		assert.True(t, false)
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.c.Validate())
+		})
 	}
 }
 

--- a/registries/registry_test.go
+++ b/registries/registry_test.go
@@ -571,6 +571,30 @@ func TestNewRegistry(t *testing.T) {
 			},
 			expectederr: true,
 		},
+		{
+			name: "invalid whitelist should not fail",
+			c: Config{
+				Type:      "dockerhub",
+				Name:      "invalidwhitelist",
+				WhiteList: []string{"[0-9]++"},
+			},
+			validate: func(reg Registry) bool {
+				return assert.True(t, len(reg.filter.whiteRegexp) == 0) &&
+					assert.True(t, len(reg.filter.failedWhiteRegexp) == 1)
+			},
+		},
+		{
+			name: "invalid blacklist should not fail",
+			c: Config{
+				Type:      "dockerhub",
+				Name:      "invalidblackist",
+				BlackList: []string{"[0-9]++"},
+			},
+			validate: func(reg Registry) bool {
+				return assert.True(t, len(reg.filter.blackRegexp) == 0) &&
+					assert.True(t, len(reg.filter.failedBlackRegexp) == 1)
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/registries/testdata/fileauthtest
+++ b/registries/testdata/fileauthtest
@@ -1,0 +1,2 @@
+username: fileuser
+password: filepassword

--- a/registries/testdata/invalidfileauthtest
+++ b/registries/testdata/invalidfileauthtest
@@ -1,0 +1,2 @@
+name: fileuser
+pssword - filepassword


### PR DESCRIPTION
Increase coverage of the New(Custom)Registry method. Also refactor the APIV2 testing methods to be usable outside that test. Major changes were switching to a table driven test.