### PR TITLE
Bug 1609700 - Use config user/pass if no auth_type

### DIFF
--- a/registries/registry.go
+++ b/registries/registry.go
@@ -386,6 +386,8 @@ func retrieveRegistryAuth(reg Config, asbNamespace string) (Config, error) {
 		return reg, nil
 	case "":
 		// Assuming that the user has either no credentials or defined them in the config
+		username = reg.User
+		password = reg.Pass
 		log.Info("Empty AuthType. Assuming credentials are defined in the config... ")
 	default:
 		return Config{}, fmt.Errorf("Unrecognized registry AuthType: %s", reg.AuthType)

--- a/registries/registry_test.go
+++ b/registries/registry_test.go
@@ -1064,12 +1064,14 @@ func TestRetrieveRegistryAuth(t *testing.T) {
 			input: Config{
 				AuthName: "empty",
 				AuthType: "",
+				User:     "duder",
+				Pass:     "topsecret",
 			},
 			expected: Config{
 				AuthName: "empty",
 				AuthType: "",
-				User:     "",
-				Pass:     "",
+				User:     "duder",
+				Pass:     "topsecret",
 			},
 		},
 		{


### PR DESCRIPTION
A regression was introduced with the quay adapter that removed these and broke default logins with user+pass and no `auth_type`. This adds them back in.