### PR TITLE
Bug 1599522 - Change error statements when discovery fails

### DIFF
--- a/registries/adapters/apiv2_adapter.go
+++ b/registries/adapters/apiv2_adapter.go
@@ -120,7 +120,8 @@ func (r APIV2Adapter) GetImageNames() ([]string, error) {
 	// discover images from URL
 	discoveredImages, err := r.discoverImages(fmt.Sprintf(apiV2CatalogURL, r.config.URL))
 	if err != nil && len(imageList) == 0 {
-		return nil, err
+		// This means no images specified in config and discovered no images. Erroring out
+		return nil, errors.New(fmt.Sprintf("failed to fetch catalog response: [%v] and failed to find images in configuration", err))
 	}
 	if len(discoveredImages) > 0 {
 		log.Debugf("Discovered images: %v", discoveredImages)
@@ -209,7 +210,7 @@ func (r APIV2Adapter) getNextImages(url string) (*apiV2CatalogResponse, string, 
 	defer resp.Body.Close()
 
 	if resp.StatusCode != 200 {
-		log.Errorf("Failed to fetch catalog response from '%s'. Expected a 200 status and got: %v", url, resp.Status)
+		log.Warnf("Failed to fetch catalog response from '%s'. Expected a 200 status and got: %v", url, resp.Status)
 		return nil, "", errors.New(resp.Status)
 	}
 

--- a/registries/adapters/apiv2_adapter.go
+++ b/registries/adapters/apiv2_adapter.go
@@ -121,7 +121,7 @@ func (r APIV2Adapter) GetImageNames() ([]string, error) {
 	discoveredImages, err := r.discoverImages(fmt.Sprintf(apiV2CatalogURL, r.config.URL))
 	if err != nil && len(imageList) == 0 {
 		// This means no images specified in config and discovered no images. Erroring out
-		return nil, errors.New(fmt.Sprintf("failed to fetch catalog response: [%v] and failed to find images in configuration", err))
+		return nil, fmt.Errorf("failed to fetch catalog response: [%v] and failed to find images in configuration", err)
 	}
 	if len(discoveredImages) > 0 {
 		log.Debugf("Discovered images: %v", discoveredImages)


### PR DESCRIPTION
Display warning when discovery fails because user can still specify images in config.