### PR TITLE
Bug 1613238 - Fix oauth client proxy

### DIFF
--- a/registries/adapters/oauth/client.go
+++ b/registries/adapters/oauth/client.go
@@ -39,7 +39,10 @@ type authResponse struct {
 // NewClient - creates and returns a *Client ready to use. If skipVerify is
 // true, it will skip verification of the remote TLS certificate.
 func NewClient(user, pass string, skipVerify bool, url *url.URL) *Client {
-	transport := &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: skipVerify}}
+	transport := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: skipVerify},
+		Proxy:           http.ProxyFromEnvironment,
+	}
 	if skipVerify == true {
 		log.Warn("skipping verification of registry TLS certificate per adapter configuration")
 	}


### PR DESCRIPTION
Since our oauth client is configuring its own Transport, it's overriding the default proxy strategy. This fix ensures we explicitly consume the proxy config from the environment, which is normally the default Transport's proxy strategy.