### PR TITLE
Bug 1623331 - Consider empty proxy vars as not configured.

### DIFF
--- a/bundle/executor.go
+++ b/bundle/executor.go
@@ -255,6 +255,11 @@ func getProxyConfig() *runtime.ProxyConfig {
 		return nil
 	}
 
+	if (httpProxyPresent && httpProxy == "") || (httpsProxyPresent && httpsProxy == "") {
+		log.Warning("Proxy env vars found, but no values configured.")
+		return nil
+	}
+
 	return &runtime.ProxyConfig{
 		HTTPProxy:  httpProxy,
 		HTTPSProxy: httpsProxy,


### PR DESCRIPTION
Setting HTTP(S)_PROXY to empty string will be considered as present in
the environment even if they are empty. But having empty values means
there is no proxy. This could be considered a misconfiguration so we log
a warning. Then we return nil as we don't want to set an improper proxy
configuration.