### PR TITLE
Bug 1613280 - only create netpolicy if one already exists

### DIFF
--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -271,35 +271,48 @@ func (p provider) CreateSandbox(podName string,
 		if err != nil {
 			return "", "", err
 		}
-		//Sandbox (i.e Namespace) was created.
+		// Sandbox (i.e Namespace) was created.
 		namespace = ns.ObjectMeta.Name
 
-		// Must create a Network policy to allow for communication from the APB pod to the target namespace.
-		networkPolicy := &networkingv1.NetworkPolicy{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: podName,
-			},
-			Spec: networkingv1.NetworkPolicySpec{
-				PodSelector: metav1.LabelSelector{},
-				Ingress: []networkingv1.NetworkPolicyIngressRule{
-					networkingv1.NetworkPolicyIngressRule{
-						From: []networkingv1.NetworkPolicyPeer{
-							networkingv1.NetworkPolicyPeer{
-								NamespaceSelector: metav1.AddLabelToSelector(&metav1.LabelSelector{}, "apb-pod-name", podName),
+		// Check to see if there are already namespaces available before
+		// creating ours
+		policies, err := k8scli.Client.NetworkingV1().NetworkPolicies(targets[0]).List(metav1.ListOptions{})
+		if err != nil {
+			return "", "", err
+		}
+
+		// If there are already network policies, let's add one to allow for
+		// communication from the APB pod to the target namespace
+		if len(policies.Items) > 0 {
+			networkPolicy := &networkingv1.NetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: podName,
+				},
+				Spec: networkingv1.NetworkPolicySpec{
+					PodSelector: metav1.LabelSelector{},
+					Ingress: []networkingv1.NetworkPolicyIngressRule{
+						networkingv1.NetworkPolicyIngressRule{
+							From: []networkingv1.NetworkPolicyPeer{
+								networkingv1.NetworkPolicyPeer{
+									NamespaceSelector: metav1.AddLabelToSelector(
+										&metav1.LabelSelector{}, "apb-pod-name", podName),
+								},
 							},
 						},
 					},
 				},
-			},
-		}
+			}
 
-		log.Debugf("Creating network policy for pod: %v to grant network access to ns: %v", podName, targets[0])
-		_, err = k8scli.Client.NetworkingV1().NetworkPolicies(targets[0]).Create(networkPolicy)
-		if err != nil {
-			log.Errorf("unable to create network policy object - %v", err)
-			return "", "", err
+			log.Debugf("Creating network policy for pod: %v to grant network access to ns: %v", podName, targets[0])
+			_, err = k8scli.Client.NetworkingV1().NetworkPolicies(targets[0]).Create(networkPolicy)
+			if err != nil {
+				log.Errorf("unable to create network policy object - %v", err)
+				return "", "", err
+			}
+			log.Debugf("Successfully created network policy for pod: %v to grant network access to ns: %v", podName, targets[0])
+		} else {
+			log.Info("No network policies found. Assuming things are open, skip network policy creation")
 		}
-		log.Debugf("Successfully created network policy for pod: %v to grant network access to ns: %v", podName, targets[0])
 	}
 
 	for i, f := range p.preSandboxCreate {

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -380,6 +380,10 @@ func (p provider) CreateSandbox(podName string,
 }
 
 func validateTargets(targets []string) error {
+	if len(targets) < 1 {
+		return fmt.Errorf("Must supply at least one target namespace")
+	}
+
 	k8scli, err := clients.Kubernetes()
 	if err != nil {
 		return err


### PR DESCRIPTION
If there are other services in the target namespace talking to each other with no network policy, during APB deployments we automatically create one that blocks the other services. This change looks to see if there are any network policies on the target namespace. If there are none, we forgo creating the network policy, assuming things are open and the transient namespace should be able to talk to the target with no issues. If there are existing network policies, then we will add ours to give the transient namespace access to the target. There is still the chance that our network policy could still affect things depending on the variety of existing network policies in place, too many to verify.