### PR TITLE
Bug 1613280 - only create netpolicy if one already exists

### DIFF
--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -188,6 +188,10 @@ func (p provider) CreateSandbox(podName string,
 	targets []string,
 	apbRole string) (string, error) {
 
+	if len(targets) < 1 {
+		return "", fmt.Errorf("Must supply at least one target namespace")
+	}
+
 	for i, f := range p.preSandboxCreate {
 		log.Debugf("Running pre create sandbox function: %v", i+1)
 		err := f(podName, namespace, targets, apbRole)
@@ -310,6 +314,12 @@ func (p provider) DestroySandbox(podName string,
 	}
 
 	log.Info("Destroying APB sandbox...")
+
+	if len(targets) < 1 {
+		log.Error("Must supply at least one target namespace")
+		return
+	}
+
 	if podName == "" {
 		log.Info("Requested destruction of APB sandbox with empty handle, skipping.")
 		return

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -236,32 +236,45 @@ func (p provider) CreateSandbox(podName string,
 		}
 	}
 
-	// Must create a Network policy to allow for comunication from the APB pod to the target namespace.
-	networkPolicy := &networkingv1.NetworkPolicy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: podName,
-		},
-		Spec: networkingv1.NetworkPolicySpec{
-			PodSelector: metav1.LabelSelector{},
-			Ingress: []networkingv1.NetworkPolicyIngressRule{
-				networkingv1.NetworkPolicyIngressRule{
-					From: []networkingv1.NetworkPolicyPeer{
-						networkingv1.NetworkPolicyPeer{
-							NamespaceSelector: metav1.AddLabelToSelector(&metav1.LabelSelector{}, "apb-pod-name", podName),
+	// Check to see if there are already namespaces available before
+	// creating ours
+	policies, err := k8scli.Client.NetworkingV1().NetworkPolicies(targets[0]).List(metav1.ListOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	// If there are already network policies, let's add one to allow for
+	// communication from the APB pod to the target namespace
+	if len(policies.Items) > 0 {
+		networkPolicy := &networkingv1.NetworkPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: podName,
+			},
+			Spec: networkingv1.NetworkPolicySpec{
+				PodSelector: metav1.LabelSelector{},
+				Ingress: []networkingv1.NetworkPolicyIngressRule{
+					networkingv1.NetworkPolicyIngressRule{
+						From: []networkingv1.NetworkPolicyPeer{
+							networkingv1.NetworkPolicyPeer{
+								NamespaceSelector: metav1.AddLabelToSelector(
+									&metav1.LabelSelector{}, "apb-pod-name", podName),
+							},
 						},
 					},
 				},
 			},
-		},
-	}
+		}
 
-	log.Debugf("Creating network policy for pod: %v to grant network access to ns: %v", podName, targets[0])
-	_, err = k8scli.Client.NetworkingV1().NetworkPolicies(targets[0]).Create(networkPolicy)
-	if err != nil {
-		log.Errorf("unable to create network policy object - %v", err)
-		return "", err
+		log.Debugf("Creating network policy for pod: %v to grant network access to ns: %v", podName, targets[0])
+		_, err = k8scli.Client.NetworkingV1().NetworkPolicies(targets[0]).Create(networkPolicy)
+		if err != nil {
+			log.Errorf("unable to create network policy object - %v", err)
+			return "", err
+		}
+		log.Debugf("Successfully created network policy for pod: %v to grant network access to ns: %v", podName, targets[0])
+	} else {
+		log.Info("No network policies found. Assuming things are open, skip network policy creation")
 	}
-	log.Debugf("Successfully created network policy for pod: %v to grant network access to ns: %v", podName, targets[0])
 
 	log.Info("Successfully created apb sandbox: [ %s ], with %s permissions in namespace %s", podName, apbRole, namespace)
 	log.Info("Running post create sandbox fuctions if defined.")


### PR DESCRIPTION
If there are other services in the target namespace talking to each other with
no network policy, during APB deployments we automatically create one that
blocks the other services. This change looks to see if there are any network
policies on the target namespace. If there are none, we forgo creating the
network policy, assuming things are open and the transient namespace should be
able to talk to the target with no issues. If there are existing network
policies, then we will add ours to give the transient namespace access to the
target. There is still the chance that our network policy could still affect
things depending on the variety of existing network policies in place, too
many to verify.