### PR TITLE
Bug 1643303 - only delete netpol if they exist

### DIFF
--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -366,14 +366,24 @@ func (p provider) DestroySandbox(podName string,
 		log.Infof("Successfully deleted rolebinding %s, namespace %s", podName, target)
 	}
 
-	log.Debugf("Deleting network policy for pod: %v to grant network access to ns: %v", podName, targets[0])
-	// Must clean up the network policy that allowed comunication from the APB pod to the target namespace.
-	err = k8scli.Client.NetworkingV1().NetworkPolicies(targets[0]).Delete(podName, &metav1.DeleteOptions{})
+	policies, err := k8scli.Client.NetworkingV1().NetworkPolicies(targets[0]).List(metav1.ListOptions{})
 	if err != nil {
-		log.Errorf("unable to delete the network policy object - %v", err)
+		log.Errorf("Something went wrong trying to determine if we have network policies! - %v", err)
 		return
 	}
-	log.Debugf("Successfully deleted network policy for pod: %v to grant network access to ns: %v", podName, targets[0])
+
+	// If there are already network policies, we need to clean up the ones we
+	// created to allow communication from the APB pod to the target namespace
+	if len(policies.Items) > 1 {
+		log.Debugf("Deleting network policy for pod: %v to grant network access to ns: %v", podName, targets[0])
+		// Must clean up the network policy that allowed comunication from the APB pod to the target namespace.
+		err = k8scli.Client.NetworkingV1().NetworkPolicies(targets[0]).Delete(podName, &metav1.DeleteOptions{})
+		if err != nil {
+			log.Errorf("unable to delete the network policy object - %v", err)
+			return
+		}
+		log.Debugf("Successfully deleted network policy for pod: %v to grant network access to ns: %v", podName, targets[0])
+	}
 
 	log.Debugf("Running post sandbox destroy hooks")
 	for i, f := range p.postSandboxDestroy {


### PR DESCRIPTION
In a previous patch we added code to only create a network
policy if there were other network policies. Otherwise, leave
it open. But during the DestroySandbox, we blindly try to
delete the network policies which we didn't create.