### PR TITLE
Bug 1763005 - add registry-proxy support

### DIFF
--- a/registries/adapters/apiv2_adapter.go
+++ b/registries/adapters/apiv2_adapter.go
@@ -80,6 +80,7 @@ func NewPartnerRhccAdapter(config Configuration) (PartnerRhccAdapter, error) {
 	return PartnerRhccAdapter{apiV2}, nil
 }
 
+// NewRegistryProxyAdapter - create a new Registry Proxy Adapter
 func NewRegistryProxyAdapter(config Configuration) (RegistryProxyAdapter, error) {
 	// we want to use a different token for this adapter, so do not call
 	// NewAPIV2Adapter directly

--- a/registries/adapters/apiv2_adapter.go
+++ b/registries/adapters/apiv2_adapter.go
@@ -46,6 +46,11 @@ type PartnerRhccAdapter struct {
 	APIV2Adapter
 }
 
+// RegistryProxyAdapter - Registry Proxy Adapter
+type RegistryProxyAdapter struct {
+	APIV2Adapter
+}
+
 // APIV2Adapter - API V2 Adapter
 type APIV2Adapter struct {
 	config Configuration
@@ -73,6 +78,34 @@ func NewPartnerRhccAdapter(config Configuration) (PartnerRhccAdapter, error) {
 		return PartnerRhccAdapter{}, err
 	}
 	return PartnerRhccAdapter{apiV2}, nil
+}
+
+func NewRegistryProxyAdapter(config Configuration) (RegistryProxyAdapter, error) {
+	// we want to use a different token for this adapter, so do not call
+	// NewAPIV2Adapter directly
+	apiv2a := APIV2Adapter{
+		config: config,
+		client: oauth.NewClient(config.User, config.Pass, config.SkipVerifyTLS, config.URL),
+	}
+
+	if len(config.Images) < 1 {
+		return RegistryProxyAdapter{},
+			fmt.Errorf("RegistryProxyAdapter requires at least one configured image")
+	}
+
+	// Authorization
+	err := apiv2a.client.Getv2WithScope(config.Images)
+	if err != nil {
+		log.Errorf("Failed to GET /v2 at %s - %v", config.URL, err)
+		return RegistryProxyAdapter{}, err
+	}
+
+	// set Tag to latest if empty
+	if apiv2a.config.Tag == "" {
+		apiv2a.config.Tag = "latest"
+	}
+
+	return RegistryProxyAdapter{apiv2a}, nil
 }
 
 // NewAPIV2Adapter - creates and returns a APIV2Adapter ready to use.

--- a/registries/adapters/apiv2_adapter_test.go
+++ b/registries/adapters/apiv2_adapter_test.go
@@ -109,7 +109,52 @@ func TestAPIV2NewAPIV2Adapter(t *testing.T) {
 		t.Fatal("Error: ", err)
 	}
 
-	ft.NotEqual(t, apiv2a, APIV2Adapter{}, "adaptor returned is not valid")
+	ft.NotEqual(t, apiv2a, APIV2Adapter{}, "adapter returned is not valid")
+}
+
+func TestNewRegistryProxyAdapter(t *testing.T) {
+	serv := adaptertest.GetAPIV2Server(t, true)
+	defer serv.Close()
+
+	testCases := []struct {
+		name        string
+		expectederr bool
+		config      Configuration
+	}{
+		{
+			name:        "Registry Proxy Adapter created with no errors",
+			expectederr: false,
+			config: Configuration{
+				URL:    adaptertest.GetURL(t, serv),
+				Images: []string{"foo/bar", "foo/baz"},
+			},
+		},
+		{
+			name:        "Registry Proxy Adapter failed to create",
+			expectederr: true,
+			config: Configuration{
+				URL:    adaptertest.GetURL(t, serv),
+				Images: []string{},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			rpAdapter, err := NewRegistryProxyAdapter(tc.config)
+			if tc.expectederr {
+				ft.Error(t, err)
+				ft.NotEmpty(t, err.Error())
+			} else if err != nil {
+				fmt.Println(err)
+				t.Fatalf("unexpected error during test: %v\n", err)
+			} else {
+				// no errors, make sure we returned the right type
+				ft.NotEqual(t, rpAdapter, RegistryProxyAdapter{},
+					"Registry Proxy adapter returned is not valid")
+			}
+		})
+	}
 }
 
 func TestNewOpenShiftAdapter(t *testing.T) {
@@ -121,7 +166,7 @@ func TestNewOpenShiftAdapter(t *testing.T) {
 	if err != nil {
 		t.Fatal("Error: ", err)
 	}
-	ft.NotEqual(t, osAdapter, OpenShiftAdapter{}, "OpenShift adaptor returned is not valid")
+	ft.NotEqual(t, osAdapter, OpenShiftAdapter{}, "OpenShift adapter returned is not valid")
 }
 
 func TestNewPartnerRhccAdapter(t *testing.T) {
@@ -133,7 +178,7 @@ func TestNewPartnerRhccAdapter(t *testing.T) {
 	if err != nil {
 		t.Fatal("Error: ", err)
 	}
-	ft.NotEqual(t, prAdapter, PartnerRhccAdapter{}, "Partner RHCC adaptor returned is not valid")
+	ft.NotEqual(t, prAdapter, PartnerRhccAdapter{}, "Partner RHCC adapter returned is not valid")
 }
 
 func TestAPIV2GetImageNames(t *testing.T) {

--- a/registries/adapters/oauth/client.go
+++ b/registries/adapters/oauth/client.go
@@ -104,7 +104,7 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 	return c.client.Do(req)
 }
 
-// Getv2WithScopes - makes a GET request to the registry's /v2/ endpoint. If a
+// Getv2WithScope - makes a GET request to the registry's /v2/ endpoint. If a
 // 401 Unauthorized response is received, this method attempts to obtain an
 // oauth token with the given imageNames as scopes and tries again with the
 // new token. If a username and password are available, they are used with

--- a/registries/adapters/oauth/client.go
+++ b/registries/adapters/oauth/client.go
@@ -17,6 +17,7 @@
 package oauth
 
 import (
+	"bytes"
 	"crypto/tls"
 	"encoding/json"
 	"errors"
@@ -103,12 +104,13 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 	return c.client.Do(req)
 }
 
-// Getv2 - makes a GET request to the registry's /v2/ endpoint. If a 401
-// Unauthorized response is received, this method attempts to obtain an oauth
-// token and tries again with the new token. If a username and password are
-// available, they are used with Basic Auth in the request to the token
-// service. This method is goroutine-safe.
-func (c *Client) Getv2() error {
+// Getv2WithScopes - makes a GET request to the registry's /v2/ endpoint. If a
+// 401 Unauthorized response is received, this method attempts to obtain an
+// oauth token with the given imageNames as scopes and tries again with the
+// new token. If a username and password are available, they are used with
+// Basic Auth in the request to the token service. This method is
+// goroutine-safe.
+func (c *Client) Getv2WithScope(imageNames []string) error {
 	// lock to prevent multiple goroutines from retrieving, and especially
 	// writing, a new token at the same time
 	c.mutex.Lock()
@@ -126,7 +128,10 @@ func (c *Client) Getv2() error {
 	switch resp.StatusCode {
 	case http.StatusUnauthorized:
 		h := resp.Header.Get("www-authenticate")
-		c.getToken(h)
+		err := c.getTokenWithScope(h, imageNames)
+		if err != nil {
+			return err
+		}
 
 		// try the new token
 		tokenReq, err := c.NewRequest("/v2/")
@@ -161,18 +166,39 @@ func (c *Client) Getv2() error {
 	return nil
 }
 
-// getToken - parses a www-authenticate header and uses the information to
-// retrieve an oauth token. The token is stored on the Client and automatically
-// added to future requests.
-func (c *Client) getToken(wwwauth string) error {
+// Getv2 - makes a GET request to the registry's /v2/ endpoint. If a 401
+// Unauthorized response is received, this method attempts to obtain an oauth
+// token and tries again with the new token. If a username and password are
+// available, they are used with Basic Auth in the request to the token
+// service. This method is goroutine-safe.
+func (c *Client) Getv2() error {
+	return c.Getv2WithScope([]string{})
+}
+
+// getTokenWithScope - parses a www-authenticate header and uses the
+// information to retrieve an oauth token. The image names are also used to
+// specify the scope of the token. The token is stored on the Client
+// and automatically added to future requests.
+func (c *Client) getTokenWithScope(wwwauth string, imageNames []string) error {
 	// compute the URL
 	u, err := parseAuthHeader(wwwauth)
 	if err != nil {
 		return err
 	}
 
-	// form the request
-	req, err := http.NewRequest("GET", u.String(), nil)
+	// build up the scopes, if imageNames is empty, the scope will be empty
+	var scope bytes.Buffer
+	for i, imageName := range imageNames {
+		if i > 0 {
+			scope.WriteString(fmt.Sprintf("&scope=repository:%s:pull", imageName))
+		} else {
+			scope.WriteString(fmt.Sprintf("?scope=repository:%s:pull", imageName))
+		}
+	}
+
+	log.Debug("token with scopes: "+fmt.Sprintf("%s%s", u.String(), scope.String()), nil)
+	// form the request, include scope if they exist
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s%s", u.String(), scope.String()), nil)
 	if err != nil {
 		log.Errorf("could not form request: %s", err.Error())
 		return err

--- a/registries/registry.go
+++ b/registries/registry.go
@@ -235,6 +235,8 @@ func NewCustomRegistry(configuration Config, adapter adapters.Adapter, asbNamesp
 			adapter = adapters.NewQuayAdapter(c)
 		case "galaxy":
 			adapter = &adapters.GalaxyAdapter{Config: c}
+		case "registry_proxy":
+			adapter, err = adapters.NewRegistryProxyAdapter(c)
 		default:
 			log.Errorf("Unknown registry type - %s", configuration.Type)
 			return Registry{}, errors.New("Unknown registry type")


### PR DESCRIPTION
The registry-proxy GET /v2 returns a WWW-Authenticate header with only a
realm: .../v2/auth the APIV2Adapter simply gets a token for /v2/auth
which is not valid for registry-proxy which seems to require a scoped
token.

In this PR, we added a new RegistryProxyAdapter that now requires the
apbs to be listed in the configuration. For each of those images listed,
we will add them to the scope when we ask for the token. This allows the
broker access to fetch the apb images.

Also, added a test to ensure registry proxy errors when no images are defined
and added a unit test for getTokenWithScope.